### PR TITLE
[CHORE] H2 -> PostgreSQL 전환 및 PostGIS 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.hibernate.orm:hibernate-spatial:6.4.4.Final'
+	implementation 'org.locationtech.jts:jts-core:1.19.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,19 +3,15 @@ spring:
     name: bts
 
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+    url: jdbc:postgresql://${SUPABASE_HOST}:5432/postgres
+    driver-class-name: org.postgresql.Driver
+    username: ${SUPABASE_USER}
+    password: ${SUPABASE_PASSWORD}
 
   jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: update   # ???
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
  ## 개요         
  H2 인메모리 DB를 Supabase PostgreSQL로 전환하고,
  공간 데이터 처리를 위한 hibernate-spatial, JTS 의존성을 추가합니다.

  ## 변경 사항
  - `build.gradle`: H2 제거 → PostgreSQL 드라이버, hibernate-spatial, jts-core 추가
  - `application.yml`: Supabase 연결 설정, ddl-auto validate, PostgreSQLDialect 적용