### PR TITLE
[FEAT] JPA Entity 4개 작성 (DongBoundary, DongLocalScore, Attraction, …

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/domain/Attraction.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/Attraction.java
@@ -1,0 +1,61 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "attraction")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Attraction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "external_id", length = 100)
+    private String externalId;
+
+    @Column(length = 200)
+    private String name;
+
+    @Column(length = 50)
+    private String category;
+
+    private String address;
+
+    @Column(columnDefinition = "GEOMETRY(Point, 4326)")
+    private Point geom;
+
+    @Column(name = "dong_code", length = 10)
+    private String dongCode;
+
+    @Column(length = 20)
+    private String source;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @Builder
+    public Attraction(String externalId, String name, String category, String address,
+                      Point geom, String dongCode, String source, OffsetDateTime createdAt) {
+        this.externalId = externalId;
+        this.name = name;
+        this.category = category;
+        this.address = address;
+        this.geom = geom;
+        this.dongCode = dongCode;
+        this.source = source;
+        this.createdAt = createdAt;
+    }
+
+    public void updateDongCode(String dongCode) {
+        this.dongCode = dongCode;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScore.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScore.java
@@ -1,0 +1,29 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "attraction_local_score")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttractionLocalScore {
+
+    @EmbeddedId
+    private AttractionLocalScoreId id;
+
+    @Column(precision = 5, scale = 2)
+    private BigDecimal score;
+
+    @Builder
+    public AttractionLocalScore(Long attractionId, LocalDate date, Integer hour, BigDecimal score) {
+        this.id = new AttractionLocalScoreId(attractionId, date, hour);
+        this.score = score;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScoreId.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScoreId.java
@@ -1,0 +1,30 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode
+public class AttractionLocalScoreId implements Serializable {
+
+    @Column(name = "attraction_id")
+    private Long attractionId;
+
+    private LocalDate date;
+
+    private Integer hour;
+
+    public AttractionLocalScoreIrd(Long attractionId, LocalDate date, Integer hour) {
+        this.attractionId = attractionId;
+        this.date = date;
+        this.hour = hour;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/DongBoundary.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/DongBoundary.java
@@ -1,0 +1,32 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.MultiPolygon;
+
+@Entity
+@Table(name = "dong_boundary")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DongBoundary {
+
+    @Id
+    @Column(name = "dong_code", length = 10)
+    private String dongCode;
+
+    @Column(name = "dong_name", length = 50)
+    private String dongName;
+
+    @Column(columnDefinition = "GEOMETRY(MultiPolygon, 4326)")
+    private MultiPolygon geom;
+
+    @Builder
+    public DongBoundary(String dongCode, String dongName, MultiPolygon geom) {
+        this.dongCode = dongCode;
+        this.dongName = dongName;
+        this.geom = geom;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/DongLocalScore.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/DongLocalScore.java
@@ -1,0 +1,44 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "dong_local_score")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DongLocalScore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "dong_code", length = 10)
+    private String dongCode;
+
+    private LocalDate date;
+
+    private Integer hour;
+
+    @Column(precision = 5, scale = 2)
+    private BigDecimal score;
+
+    @Column(name = "breakdown_json", columnDefinition = "jsonb")
+    private String breakdownJson;
+
+    @Builder
+    public DongLocalScore(String dongCode, LocalDate date, Integer hour,
+                          BigDecimal score, String breakdownJson) {
+        this.dongCode = dongCode;
+        this.date = date;
+        this.hour = hour;
+        this.score = score;
+        this.breakdownJson = breakdownJson;
+    }
+}


### PR DESCRIPTION
## 개요                                                                                                                                                        
  Supabase에 생성한 4개 테이블에 대한 JPA Entity 클래스를 작성합니다.

  ## 변경 사항
  - DongBoundary: 행정동 경계 폴리곤 (MultiPolygon)
  - DongLocalScore: 찐로컬 지수 시계열 (jsonb 포함)
  - Attraction: 관광지 좌표 (Point), updateDongCode() 메서드 포함
  - AttractionLocalScore: 복합 PK (attraction_id, date, hour)

  ## 관련 이슈
  close #11
