### PR TITLE
[FEAT] 행정동 GeoJSON import 스크립트 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ application-secret.properties
 *.zip
 *.tar.gz
 *.rar
+
+# GeoJSON 데이터 파일 (용량이 크므로 직접 다운로드)
+src/main/resources/geojson/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # BeyondToursSeoul-BTS_back
+
+## 초기 데이터 설정
+
+### 행정동 GeoJSON
+행정동 경계 데이터는 용량 문제로 git에서 제외되어 있습니다. 아래 순서로 직접 준비해주세요.
+
+1. [vuski/admdongkor](https://github.com/vuski/admdongkor) 에서 최신 `HangJeongDong_ver*.geojson` 다운로드
+2. 파일명을 `seoul_dong.geojson` 으로 변경
+3. `src/main/resources/geojson/seoul_dong.geojson` 경로에 저장
+4. 앱 실행 시 서울 행정동 데이터가 자동으로 DB에 적재됩니다

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-	implementation 'org.hibernate.orm:hibernate-spatial:6.4.4.Final'
 	implementation 'org.locationtech.jts:jts-core:1.19.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScoreId.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScoreId.java
@@ -22,7 +22,7 @@ public class AttractionLocalScoreId implements Serializable {
 
     private Integer hour;
 
-    public AttractionLocalScoreIrd(Long attractionId, LocalDate date, Integer hour) {
+    public AttractionLocalScoreId(Long attractionId, LocalDate date, Integer hour) {
         this.attractionId = attractionId;
         this.date = date;
         this.hour = hour;

--- a/src/main/java/com/beyondtoursseoul/bts/domain/DongBoundary.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/DongBoundary.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.locationtech.jts.geom.MultiPolygon;
 
 @Entity
 @Table(name = "dong_boundary")
@@ -20,13 +19,13 @@ public class DongBoundary {
     @Column(name = "dong_name", length = 50)
     private String dongName;
 
-    @Column(columnDefinition = "GEOMETRY(MultiPolygon, 4326)")
-    private MultiPolygon geom;
+    // geom 컬럼은 JdbcTemplate + ST_GeomFromGeoJSON으로 직접 관리
+    @Transient
+    private Object geom;
 
     @Builder
-    public DongBoundary(String dongCode, String dongName, MultiPolygon geom) {
+    public DongBoundary(String dongCode, String dongName) {
         this.dongCode = dongCode;
         this.dongName = dongName;
-        this.geom = geom;
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/repository/DongBoundaryRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/DongBoundaryRepository.java
@@ -1,0 +1,7 @@
+package com.beyondtoursseoul.bts.repository;
+
+import com.beyondtoursseoul.bts.domain.DongBoundary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DongBoundaryRepository extends JpaRepository<DongBoundary, String> {
+}

--- a/src/main/java/com/beyondtoursseoul/bts/runner/DongBoundaryImportRunner.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/DongBoundaryImportRunner.java
@@ -1,0 +1,42 @@
+package com.beyondtoursseoul.bts.runner;
+
+import com.beyondtoursseoul.bts.repository.DongBoundaryRepository;
+import com.beyondtoursseoul.bts.service.DongBoundaryImportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DongBoundaryImportRunner implements ApplicationRunner {
+
+    private final DongBoundaryImportService dongBoundaryImportService;
+    private final DongBoundaryRepository dongBoundaryRepository;
+
+    private static final String GEOJSON_PATH = "geojson/seoul_dong.geojson";
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        if (dongBoundaryRepository.count() > 0) {
+            log.info("행정동 경계 데이터가 이미 존재합니다. import를 건너뜁니다.");
+            return;
+        }
+
+        ClassPathResource resource = new ClassPathResource(GEOJSON_PATH);
+        if (!resource.exists()) {
+            log.warn("GeoJSON 파일을 찾을 수 없습니다: {}", GEOJSON_PATH);
+            return;
+        }
+
+        log.info("행정동 경계 데이터 import를 시작합니다.");
+        try (InputStream inputStream = resource.getInputStream()) {
+            dongBoundaryImportService.importFromGeoJson(inputStream);
+        }
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/DongBoundaryImportService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/DongBoundaryImportService.java
@@ -1,0 +1,54 @@
+package com.beyondtoursseoul.bts.service;
+
+import com.beyondtoursseoul.bts.repository.DongBoundaryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DongBoundaryImportService {
+
+    private final DongBoundaryRepository dongBoundaryRepository;
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void importFromGeoJson(InputStream inputStream) throws Exception {
+        JsonNode root = objectMapper.readTree(inputStream);
+        JsonNode features = root.get("features");
+
+        List<Object[]> batchArgs = new ArrayList<>();
+
+        for (JsonNode feature : features) {
+            JsonNode properties = feature.get("properties");
+            String admCd = properties.get("adm_cd").asText();
+
+            // 서울만 적재 (코드 앞 2자리 = 11)
+            if (!admCd.startsWith("11")) continue;
+
+            // 10자리 → 8자리 통일 (생활인구 API 기준)
+            String dongCode = admCd.length() > 8 ? admCd.substring(0, 8) : admCd;
+            String dongName = properties.get("adm_nm").asText();
+            String geomJson = objectMapper.writeValueAsString(feature.get("geometry"));
+
+            batchArgs.add(new Object[]{dongCode, dongName, geomJson});
+        }
+
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO dong_boundary (dong_code, dong_name, geom) VALUES (?, ?, ST_GeomFromGeoJSON(?))",
+                batchArgs
+        );
+
+        log.info("행정동 경계 데이터 {}건 저장 완료", batchArgs.size());
+    }
+}


### PR DESCRIPTION
## 개요
> 서울시 행정동 경계 GeoJSON 데이터를 dong_boundary 테이블에 적재하는
스크립트를 작성합니다..

## 변경 사항
>
- 행정동 GeoJSON 파일 다운로드 (vuski/admdongkor)

- GeoJSON → dong_boundary 파싱 및 저장 로직 구현

- 행정동 코드 자릿수 통일 (8자리 기준)

- 최초 1회 실행용 import 엔드포인트 또는 ApplicationRunner 구현


## 관련 이슈
close #13
