### PR TITLE
feat: 서울시 내국인 생활인구 API 연동

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/dto/LocalResidentApiResponseDto.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/LocalResidentApiResponseDto.java
@@ -1,0 +1,61 @@
+package com.beyondtoursseoul.bts.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * 서울시 내국인 생활인구 API (OA-14991) 응답 DTO
+ * 서비스명: SPOP_LOCAL_RESD_DONG
+ */
+@Getter
+@NoArgsConstructor
+public class LocalResidentApiResponseDto {
+
+    @JsonProperty("SPOP_LOCAL_RESD_DONG")
+    private Body body;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Body {
+
+        @JsonProperty("list_total_count")
+        private int totalCount;
+
+        @JsonProperty("RESULT")
+        private Result result;
+
+        @JsonProperty("row")
+        private List<Row> rows;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Result {
+
+        @JsonProperty("CODE")
+        private String code;
+
+        @JsonProperty("MESSAGE")
+        private String message;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Row {
+
+        @JsonProperty("STDR_DE_ID")
+        private String date;           // 기준일 (YYYYMMDD)
+
+        @JsonProperty("TMZON_PD_SE")
+        private String timeZone;       // 시간대 코드 (00~23)
+
+        @JsonProperty("ADSTRD_CODE_SE")
+        private String dongCode;       // 행정동코드
+
+        @JsonProperty("TOT_LVPOP_CO")
+        private String totalPopulation; // 총생활인구수
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/repository/DongLocalScoreRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/DongLocalScoreRepository.java
@@ -1,0 +1,14 @@
+package com.beyondtoursseoul.bts.repository;
+
+import com.beyondtoursseoul.bts.domain.DongLocalScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DongLocalScoreRepository extends JpaRepository<DongLocalScore, Long> {
+
+    boolean existsByDongCodeAndDateAndHour(String dongCode, LocalDate date, Integer hour);
+
+    List<DongLocalScore> findByDate(LocalDate date);
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/LocalResidentApiService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/LocalResidentApiService.java
@@ -1,0 +1,104 @@
+package com.beyondtoursseoul.bts.service;
+
+import com.beyondtoursseoul.bts.dto.LocalResidentApiResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class
+LocalResidentApiService {
+
+    private static final String SERVICE_NAME = "SPOP_LOCAL_RESD_DONG";
+    private static final int PAGE_SIZE = 1000;
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RestClient restClient;
+
+    @Value("${SEOUL_OPEN_API_KEY}")
+    private String apiKey;
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public LocalResidentApiService() {
+        this.restClient = RestClient.create();
+    }
+
+    /**
+     * 최근 7일 내 데이터가 존재하는 가장 최신 날짜 탐색 (1건만 조회해서 빠르게 확인)
+     */
+    public LocalDate findLatestAvailableDate() {
+        for (int i = 1; i <= 7; i++) {
+            LocalDate date = LocalDate.now().minusDays(i);
+            String url = buildUrl(date.format(DATE_FORMAT), 1, 1);
+
+            LocalResidentApiResponseDto response = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(LocalResidentApiResponseDto.class);
+
+            if (response != null && response.getBody() != null
+                    && response.getBody().getTotalCount() > 0) {
+                log.info("최신 생활인구 데이터 날짜: {}", date);
+                return date;
+            }
+        }
+        throw new IllegalStateException("최근 7일 내 내국인 생활인구 데이터를 찾을 수 없습니다.");
+    }
+
+    /**
+     * 특정 날짜의 내국인 생활인구 전체 데이터 수집
+     * 서울 행정동(11로 시작)만 필터링하여 반환
+     */
+    public List<LocalResidentApiResponseDto.Row> fetchByDate(LocalDate date) {
+        String dateStr = date.format(DATE_FORMAT);
+        List<LocalResidentApiResponseDto.Row> allRows = new ArrayList<>();
+
+        int start = 1;
+        int totalCount = Integer.MAX_VALUE;
+
+        while (start <= totalCount) {
+            int end = start + PAGE_SIZE - 1;
+            String url = buildUrl(dateStr, start, end);
+
+            log.info("내국인 생활인구 API 호출: {} ({}-{})", dateStr, start, end);
+
+            LocalResidentApiResponseDto response = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(LocalResidentApiResponseDto.class);
+
+            if (response == null || response.getBody() == null || response.getBody().getRows() == null) {
+                log.warn("응답 데이터 없음: {} ({}-{})", dateStr, start, end);
+                break;
+            }
+
+            totalCount = response.getBody().getTotalCount();
+
+            response.getBody().getRows().stream()
+                    .filter(row -> row.getDongCode() != null && row.getDongCode().startsWith("11"))
+                    .forEach(allRows::add);
+
+            start += PAGE_SIZE;
+        }
+
+        log.info("내국인 생활인구 수집 완료: {}건 ({})", allRows.size(), dateStr);
+        return allRows;
+    }
+
+    private String buildUrl(String date, int start, int end) {
+        return String.format(
+                "http://openapi.seoul.go.kr:8088/%s/json/%s/%d/%d/%s",
+                apiKey, SERVICE_NAME, start, end, date
+        );
+    }
+}

--- a/src/test/java/com/beyondtoursseoul/bts/BtsApplicationTests.java
+++ b/src/test/java/com/beyondtoursseoul/bts/BtsApplicationTests.java
@@ -1,13 +1,38 @@
 package com.beyondtoursseoul.bts;
 
+import com.beyondtoursseoul.bts.dto.LocalResidentApiResponseDto;
+import com.beyondtoursseoul.bts.service.LocalResidentApiService;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @SpringBootTest
 class BtsApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private LocalResidentApiService localResidentApiService;
 
+    @Test
+    void contextLoads() {
+    }
+
+    @Test
+    void 내국인_생활인구_API_호출_테스트() {
+        LocalDate latestDate = localResidentApiService.findLatestAvailableDate();
+        List<LocalResidentApiResponseDto.Row> rows = localResidentApiService.fetchByDate(latestDate);
+
+        System.out.println("수집된 행 수: " + rows.size());
+
+        if (!rows.isEmpty()) {
+            LocalResidentApiResponseDto.Row sample = rows.get(0);
+            System.out.println("샘플 데이터:");
+            System.out.println("  행정동코드: " + sample.getDongCode());
+            System.out.println("  날짜: " + sample.getDate());
+            System.out.println("  시간대: " + sample.getTimeZone());
+            System.out.println("  총생활인구: " + sample.getTotalPopulation());
+        }
+    }
 }


### PR DESCRIPTION
## 개요

>   서울 열린데이터광장 내국인 생활인구 API(OA-14991)를 연동합니다.                                                                                                       
>   행정동별 시간대별 생활인구 데이터를 수집하며, 찐로컬 지수 계산의 원재료로 사용됩니다.


## 변경 사항

>   - LocalResidentApiResponseDto: API 응답 구조 DTO 작성
>   - LocalResidentApiService: 날짜별 전체 데이터 수집 + 페이지네이션
>   - findLatestAvailableDate(): 데이터 지연 발행 대응, 최근 7일 내 최신 날짜 자동 탐색
>   - DongLocalScoreRepository: 기본 레포지토리 추가
>   - BtsApplicationTests: API 연동 테스트 추가
> 


## 관련 이슈
close #16
