### PR TITLE
[FEAT] 회원가입/로그인 관련 백엔드 API 기본 구조 구현

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/controller/AuthController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.beyondtoursseoul.bts.controller;
+
+import com.beyondtoursseoul.bts.dto.auth.AuthResponse;
+import com.beyondtoursseoul.bts.dto.auth.LoginRequest;
+import com.beyondtoursseoul.bts.dto.auth.MeResponse;
+import com.beyondtoursseoul.bts.dto.auth.SignupRequest;
+import com.beyondtoursseoul.bts.service.auth.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public AuthResponse signup(@RequestBody SignupRequest request) {
+        return authService.signup(request);
+    }
+
+    @PostMapping("/login")
+    public AuthResponse login(@RequestBody LoginRequest request) {
+        return authService.login(request);
+    }
+
+    @GetMapping("/me")
+    public MeResponse me(@AuthenticationPrincipal Jwt jwt) {
+        return authService.me(jwt);
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/Profile.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/Profile.java
@@ -1,0 +1,41 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "profiles")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Profile {
+
+    @Id
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+    private String nickname;
+
+    @Column(name = "preferred_language")
+    private String preferredLanguage;
+
+    @Column(name = "visit_count")
+    private Integer visitCount;
+
+    @Column(name = "local_preference")
+    private String localPreference;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/auth/AuthResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/auth/AuthResponse.java
@@ -1,0 +1,16 @@
+package com.beyondtoursseoul.bts.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthResponse {
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType;
+    private Long expiresIn;
+    private String userId;
+    private String email;
+    private String message;
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/auth/LoginRequest.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/auth/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.beyondtoursseoul.bts.dto.auth;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/auth/MeResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/auth/MeResponse.java
@@ -1,0 +1,16 @@
+package com.beyondtoursseoul.bts.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MeResponse {
+    private String userId;
+    private String email;
+    private String role;
+    private String nickname;
+    private String preferredLanguage;
+    private Integer visitCount;
+    private String localPreference;
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/auth/SignupRequest.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/auth/SignupRequest.java
@@ -1,0 +1,11 @@
+package com.beyondtoursseoul.bts.dto.auth;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/beyondtoursseoul/bts/repository/ProfileRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/ProfileRepository.java
@@ -1,0 +1,9 @@
+package com.beyondtoursseoul.bts.repository;
+
+import com.beyondtoursseoul.bts.domain.Profile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProfileRepository extends JpaRepository<Profile, UUID> {
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/auth/AuthService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/auth/AuthService.java
@@ -1,0 +1,16 @@
+package com.beyondtoursseoul.bts.service.auth;
+
+import com.beyondtoursseoul.bts.dto.auth.AuthResponse;
+import com.beyondtoursseoul.bts.dto.auth.LoginRequest;
+import com.beyondtoursseoul.bts.dto.auth.MeResponse;
+import com.beyondtoursseoul.bts.dto.auth.SignupRequest;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public interface AuthService {
+
+    AuthResponse signup(SignupRequest request);
+
+    AuthResponse login(LoginRequest request);
+
+    MeResponse me(Jwt jwt);
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/auth/SupabaseAuthService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/auth/SupabaseAuthService.java
@@ -1,0 +1,119 @@
+package com.beyondtoursseoul.bts.service.auth;
+
+import com.beyondtoursseoul.bts.domain.Profile;
+import com.beyondtoursseoul.bts.dto.auth.AuthResponse;
+import com.beyondtoursseoul.bts.dto.auth.LoginRequest;
+import com.beyondtoursseoul.bts.dto.auth.MeResponse;
+import com.beyondtoursseoul.bts.dto.auth.SignupRequest;
+import com.beyondtoursseoul.bts.repository.ProfileRepository;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SupabaseAuthService implements AuthService {
+
+    private final ProfileRepository profileRepository;
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${SUPABASE_URL}")
+    private String supabaseUrl;
+
+    @Value("${SUPABASE_PUBLISHABLE_KEY}")
+    private String publishableKey;
+
+//
+    @Override
+    public AuthResponse signup(SignupRequest request) {
+        String rawResponse = restClient.post()
+                .uri(supabaseUrl + "/auth/v1/signup")
+                .header("apikey", publishableKey)
+                .header("Authorization", "Bearer " + publishableKey)
+                .header("Content-Type", "application/json")
+                .body(request)
+                .retrieve()
+                .body(String.class);
+
+        System.out.println("signup raw response = " + rawResponse);
+
+        throw new IllegalStateException(rawResponse);
+    }
+
+    @Override
+    public AuthResponse login(LoginRequest request) {
+        SupabaseAuthResult result = restClient.post()
+                .uri(supabaseUrl + "/auth/v1/token?grant_type=password")
+                .header("apikey", publishableKey)
+                .header("Authorization", "Bearer " + publishableKey)
+                .header("Content-Type", "application/json")
+                .body(request)
+                .retrieve().body(SupabaseAuthResult.class);
+
+        if (result == null || result.getUser() == null) {
+            throw new IllegalStateException("로그인 응답이 올바르지 않습니다.");
+        }
+
+        return new AuthResponse(
+                result.getAccessToken(),
+                result.getRefreshToken(),
+                result.getTokenType(),
+                result.getExpiresIn(),
+                result.getUser().getId(),
+                result.getUser().getEmail(),
+                "로그인 성공"
+        );
+    }
+
+    @Override
+    public MeResponse me(Jwt jwt) {
+        String userId = jwt.getSubject();
+        String email = jwt.getClaimAsString("email");
+        String role = jwt.getClaimAsString("role");
+
+        Profile profile = profileRepository.findById(UUID.fromString(userId)).orElse(null);
+
+        return new MeResponse(
+                userId,
+                email,
+                role,
+                profile != null ? profile.getNickname() : null,
+                profile != null ? profile.getPreferredLanguage() : null,
+                profile != null ? profile.getVisitCount() : null,
+                profile != null ? profile.getLocalPreference() : null
+        );
+    }
+
+    @Getter
+    @NoArgsConstructor
+    private static class SupabaseAuthResult {
+
+        @JsonProperty("access_token")
+        private String accessToken;
+
+        @JsonProperty("refresh_token")
+        private String refreshToken;
+
+        @JsonProperty("token_type")
+        private String tokenType;
+
+        @JsonProperty("expires_in")
+        private Long expiresIn;
+
+        private SupabaseUser user;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    private static class SupabaseUser {
+        private String id;
+        private String email;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ spring:
         jwt:
           issuer-uri: ${SUPABASE_JWT_ISSUER}
           jwk-set-uri: ${SUPABASE_JWT_JWKS_URI}
+          jws-algorithms: ES256
 
   config:
     import: optional:file:.env[.properties] # .env파일에서 환경변수 로드


### PR DESCRIPTION
## 개요
Supabase Auth 기반 이메일 회원가입/로그인 및 현재 사용자 조회 API를 구현했습니다.

## 변경 사항
- `signup`, `login`, `me` API 추가
- `Profile` 엔티티/리포지토리 추가
- Supabase Auth 및 `profiles` 연동
- `application.yml`에 `ES256` JWT 검증 설정 추가

## 테스트
- [x] 회원가입 API 호출 확인
- [x] 로그인 성공 및 access token 발급 확인
- [x] `/me` 호출 성공

## 관련 이슈
close #19
