### PR TITLE
[FEAT] 단기체류 외국인 생활인구 API 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'org.hibernate.orm:hibernate-spatial:6.4.4.Final'
+	implementation 'org.hibernate.orm:hibernate-spatial:7.0.0.Final'
 	implementation 'org.locationtech.jts:jts-core:1.19.0'
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 

--- a/src/main/java/com/beyondtoursseoul/bts/dto/ForeignResidentApiResponseDto.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/ForeignResidentApiResponseDto.java
@@ -1,0 +1,61 @@
+package com.beyondtoursseoul.bts.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 서울시 단기체류 외국인 생활인구 API (OA-14993) 응답 DTO
+ * 서비스명: SPOP_FORN_TEMP_RESD_DONG
+ */
+@Getter
+@NoArgsConstructor
+public class ForeignResidentApiResponseDto {
+
+    @JsonProperty("SPOP_FORN_TEMP_RESD_DONG")
+    private Body body;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Body {
+
+        @JsonProperty("list_total_count")
+        private int totalCount;
+
+        @JsonProperty("RESULT")
+        private Result result;
+
+        @JsonProperty("row")
+        private List<Row> rows;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Result {
+
+        @JsonProperty("CODE")
+        private String code;
+
+        @JsonProperty("MESSAGE")
+        private String message;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Row {
+
+        @JsonProperty("STDR_DE_ID")
+        private String date;           // 기준일 (YYYYMMDD)
+
+        @JsonProperty("TMZON_PD_SE")
+        private String timeZone;       // 시간대 코드 (00~23)
+
+        @JsonProperty("ADSTRD_CODE_SE")
+        private String dongCode;       // 행정동코드
+
+        @JsonProperty("TOT_LVPOP_CO")
+        private String totalPopulation; // 외국인 총생활인구수
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/ForeignResidentApiService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/ForeignResidentApiService.java
@@ -1,0 +1,99 @@
+package com.beyondtoursseoul.bts.service;
+
+import com.beyondtoursseoul.bts.dto.ForeignResidentApiResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class ForeignResidentApiService {
+
+    private static final String SERVICE_NAME = "SPOP_FORN_TEMP_RESD_DONG";
+    private static final int PAGE_SIZE = 1000;
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RestClient restClient;
+
+    @Value("${SEOUL_OPEN_API_KEY}")
+    private String apiKey;
+
+    public ForeignResidentApiService() {
+        this.restClient = RestClient.create();
+    }
+
+    /**
+     * 최근 7일 내 데이터가 존재하는 가장 최신 날짜 탐색
+     */
+    public LocalDate findLatestAvailableDate() {
+        for (int i = 1; i <= 7; i++) {
+            LocalDate date = LocalDate.now().minusDays(i);
+            String url = buildUrl(date.format(DATE_FORMAT), 1, 1);
+
+            ForeignResidentApiResponseDto response = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(ForeignResidentApiResponseDto.class);
+
+            if (response != null && response.getBody() != null
+                    && response.getBody().getTotalCount() > 0) {
+                log.info("최신 외국인 생활인구 데이터 날짜: {}", date);
+                return date;
+            }
+        }
+        throw new IllegalStateException("최근 7일 내 단기체류 외국인 생활인구 데이터를 찾을 수 없습니다.");
+    }
+
+    /**
+     * 특정 날짜의 단기체류 외국인 생활인구 전체 데이터 수집
+     * 서울 행정동(11로 시작)만 필터링하여 반환
+     */
+    public List<ForeignResidentApiResponseDto.Row> fetchByDate(LocalDate date) {
+        String dateStr = date.format(DATE_FORMAT);
+        List<ForeignResidentApiResponseDto.Row> allRows = new ArrayList<>();
+
+        int start = 1;
+        int totalCount = Integer.MAX_VALUE;
+
+        while (start <= totalCount) {
+            int end = start + PAGE_SIZE - 1;
+            String url = buildUrl(dateStr, start, end);
+
+            log.info("외국인 생활인구 API 호출: {} ({}-{})", dateStr, start, end);
+
+            ForeignResidentApiResponseDto response = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(ForeignResidentApiResponseDto.class);
+
+            if (response == null || response.getBody() == null || response.getBody().getRows() == null) {
+                log.warn("응답 데이터 없음: {} ({}-{})", dateStr, start, end);
+                break;
+            }
+
+            totalCount = response.getBody().getTotalCount();
+
+            response.getBody().getRows().stream()
+                    .filter(row -> row.getDongCode() != null && row.getDongCode().startsWith("11"))
+                    .forEach(allRows::add);
+
+            start += PAGE_SIZE;
+        }
+
+        log.info("외국인 생활인구 수집 완료: {}건 ({})", allRows.size(), dateStr);
+        return allRows;
+    }
+
+    private String buildUrl(String date, int start, int end) {
+        return String.format(
+                "http://openapi.seoul.go.kr:8088/%s/json/%s/%d/%d/%s",
+                apiKey, SERVICE_NAME, start, end, date
+        );
+    }
+}

--- a/src/test/java/com/beyondtoursseoul/bts/BtsApplicationTests.java
+++ b/src/test/java/com/beyondtoursseoul/bts/BtsApplicationTests.java
@@ -1,6 +1,8 @@
 package com.beyondtoursseoul.bts;
 
+import com.beyondtoursseoul.bts.dto.ForeignResidentApiResponseDto;
 import com.beyondtoursseoul.bts.dto.LocalResidentApiResponseDto;
+import com.beyondtoursseoul.bts.service.ForeignResidentApiService;
 import com.beyondtoursseoul.bts.service.LocalResidentApiService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +17,9 @@ class BtsApplicationTests {
     @Autowired
     private LocalResidentApiService localResidentApiService;
 
+    @Autowired
+    private ForeignResidentApiService foreignResidentApiService;
+
     @Test
     void contextLoads() {
     }
@@ -28,6 +33,23 @@ class BtsApplicationTests {
 
         if (!rows.isEmpty()) {
             LocalResidentApiResponseDto.Row sample = rows.get(0);
+            System.out.println("샘플 데이터:");
+            System.out.println("  행정동코드: " + sample.getDongCode());
+            System.out.println("  날짜: " + sample.getDate());
+            System.out.println("  시간대: " + sample.getTimeZone());
+            System.out.println("  총생활인구: " + sample.getTotalPopulation());
+        }
+    }
+
+    @Test
+    void 외국인_생활인구_API_호출_테스트() {
+        LocalDate latestDate = foreignResidentApiService.findLatestAvailableDate();
+        List<ForeignResidentApiResponseDto.Row> rows = foreignResidentApiService.fetchByDate(latestDate);
+
+        System.out.println("수집된 행 수: " + rows.size());
+
+        if (!rows.isEmpty()) {
+            ForeignResidentApiResponseDto.Row sample = rows.get(0);
             System.out.println("샘플 데이터:");
             System.out.println("  행정동코드: " + sample.getDongCode());
             System.out.println("  날짜: " + sample.getDate());

--- a/src/test/java/com/beyondtoursseoul/bts/service/ForeignResidentApiServiceTest.java
+++ b/src/test/java/com/beyondtoursseoul/bts/service/ForeignResidentApiServiceTest.java
@@ -1,0 +1,45 @@
+package com.beyondtoursseoul.bts.service;
+
+import com.beyondtoursseoul.bts.dto.ForeignResidentApiResponseDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ForeignResidentApiServiceTest {
+
+    @Autowired
+    private ForeignResidentApiService foreignResidentApiService;
+
+    @Test
+    void 최신_데이터_날짜_탐색() {
+        LocalDate date = foreignResidentApiService.findLatestAvailableDate();
+
+        System.out.println("최신 외국인 생활인구 데이터 날짜: " + date);
+        assertThat(date).isNotNull();
+        assertThat(date).isBefore(LocalDate.now());
+    }
+
+    @Test
+    void 특정_날짜_외국인_생활인구_수집() {
+        LocalDate date = foreignResidentApiService.findLatestAvailableDate();
+        List<ForeignResidentApiResponseDto.Row> rows = foreignResidentApiService.fetchByDate(date);
+
+        System.out.println("수집된 행 수: " + rows.size());
+        if (!rows.isEmpty()) {
+            ForeignResidentApiResponseDto.Row sample = rows.get(0);
+            System.out.println("샘플 행 - 날짜: " + sample.getDate()
+                    + ", 시간대: " + sample.getTimeZone()
+                    + ", 행정동코드: " + sample.getDongCode()
+                    + ", 생활인구: " + sample.getTotalPopulation());
+        }
+
+        assertThat(rows).isNotEmpty();
+        assertThat(rows).allMatch(row -> row.getDongCode().startsWith("11"));
+    }
+}


### PR DESCRIPTION
## 개요

> 서울시 단기체류 외국인 생활인구 API(OA-14993)를 연동합니다.
> 찐로컬 지수 계산의 외국인 체류 비율 패널티 항목에 사용될 데이터입니다.
> 

## 변경 사항

>   - `ForeignResidentApiResponseDto` — OA-14993 응답 매핑 DTO (서비스명: SPOP_FORN_TEMP_RESD_DONG)
>   - `ForeignResidentApiService` — 최신 날짜 탐색 및 페이징 수집 (서울 행정동 11* 필터링)
>   - `BtsApplicationTests`, `ForeignResidentApiServiceTest` — 통합 테스트 추가
> 

## 관련 이슈
close #26
