### PR TITLE
[FEAT] 찐 로컬 지수 계산 구현

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScore.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScore.java
@@ -22,8 +22,8 @@ public class AttractionLocalScore {
     private BigDecimal score;
 
     @Builder
-    public AttractionLocalScore(Long attractionId, LocalDate date, Integer hour, BigDecimal score) {
-        this.id = new AttractionLocalScoreId(attractionId, date, hour);
+    public AttractionLocalScore(Long attractionId, LocalDate date, String timeSlot, BigDecimal score) {
+        this.id = new AttractionLocalScoreId(attractionId, date, timeSlot);
         this.score = score;
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScoreId.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/AttractionLocalScoreId.java
@@ -20,11 +20,12 @@ public class AttractionLocalScoreId implements Serializable {
 
     private LocalDate date;
 
-    private Integer hour;
+    @Column(name = "time_slot", length = 20)
+    private String timeSlot;
 
-    public AttractionLocalScoreId(Long attractionId, LocalDate date, Integer hour) {
+    public AttractionLocalScoreId(Long attractionId, LocalDate date, String timeSlot) {
         this.attractionId = attractionId;
         this.date = date;
-        this.hour = hour;
+        this.timeSlot = timeSlot;
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/domain/DongLocalScore.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/DongLocalScore.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
@@ -24,20 +23,21 @@ public class DongLocalScore {
 
     private LocalDate date;
 
-    private Integer hour;
+    @Column(name = "time_slot", length = 20)
+    private String timeSlot;
 
     @Column(precision = 5, scale = 2)
     private BigDecimal score;
 
-    @Column(name = "breakdown_json", columnDefinition = "jsonb")
+    @Column(name = "breakdown_json", columnDefinition = "text")
     private String breakdownJson;
 
     @Builder
-    public DongLocalScore(String dongCode, LocalDate date, Integer hour,
+    public DongLocalScore(String dongCode, LocalDate date, String timeSlot,
                           BigDecimal score, String breakdownJson) {
         this.dongCode = dongCode;
         this.date = date;
-        this.hour = hour;
+        this.timeSlot = timeSlot;
         this.score = score;
         this.breakdownJson = breakdownJson;
     }

--- a/src/main/java/com/beyondtoursseoul/bts/domain/DongPopulationRaw.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/DongPopulationRaw.java
@@ -1,0 +1,51 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "dong_population_raw")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DongPopulationRaw {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "dong_code", length = 10, nullable = false)
+    private String dongCode;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(name = "time_slot", length = 20, nullable = false)
+    private String timeSlot;
+
+    @Column(name = "korean_pop", nullable = false, precision = 10, scale = 4)
+    private BigDecimal koreanPop;
+
+    @Column(name = "foreign_pop", nullable = false, precision = 10, scale = 4)
+    private BigDecimal foreignPop;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @Builder
+    public DongPopulationRaw(String dongCode, LocalDate date, String timeSlot,
+                              BigDecimal koreanPop, BigDecimal foreignPop) {
+        this.dongCode = dongCode;
+        this.date = date;
+        this.timeSlot = timeSlot;
+        this.koreanPop = koreanPop;
+        this.foreignPop = foreignPop;
+        this.createdAt = OffsetDateTime.now();
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/repository/DongLocalScoreRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/DongLocalScoreRepository.java
@@ -8,7 +8,9 @@ import java.util.List;
 
 public interface DongLocalScoreRepository extends JpaRepository<DongLocalScore, Long> {
 
-    boolean existsByDongCodeAndDateAndHour(String dongCode, LocalDate date, Integer hour);
+    boolean existsByDongCodeAndDateAndTimeSlot(String dongCode, LocalDate date, String timeSlot);
 
     List<DongLocalScore> findByDate(LocalDate date);
+
+    void deleteByDateAndTimeSlot(LocalDate date, String timeSlot);
 }

--- a/src/main/java/com/beyondtoursseoul/bts/repository/DongPopulationRawRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/DongPopulationRawRepository.java
@@ -1,0 +1,16 @@
+package com.beyondtoursseoul.bts.repository;
+
+import com.beyondtoursseoul.bts.domain.DongPopulationRaw;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DongPopulationRawRepository extends JpaRepository<DongPopulationRaw, Long> {
+
+    boolean existsByDate(LocalDate date);
+
+    List<DongPopulationRaw> findByDateAndTimeSlot(LocalDate date, String timeSlot);
+
+    List<DongPopulationRaw> findByTimeSlotAndDateBetween(String timeSlot, LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/beyondtoursseoul/bts/runner/InitialDataLoader.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/InitialDataLoader.java
@@ -1,0 +1,56 @@
+package com.beyondtoursseoul.bts.runner;
+
+import com.beyondtoursseoul.bts.repository.DongLocalScoreRepository;
+import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
+import com.beyondtoursseoul.bts.service.LocalResidentApiService;
+import com.beyondtoursseoul.bts.service.score.LocalScoreCalculateService;
+import com.beyondtoursseoul.bts.service.score.PopulationCollectService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(2)
+public class InitialDataLoader implements ApplicationRunner {
+
+    private final DongPopulationRawRepository rawRepository;
+    private final DongLocalScoreRepository scoreRepository;
+    private final PopulationCollectService populationCollectService;
+    private final LocalScoreCalculateService localScoreCalculateService;
+    private final LocalResidentApiService localResidentApiService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        LocalDate latestDate = localResidentApiService.findLatestAvailableDate();
+
+        if (rawRepository.count() == 0) {
+            log.info("초기 4주치 생활인구 데이터 적재 시작");
+            for (int i = 27; i >= 0; i--) {
+                LocalDate date = latestDate.minusDays(i);
+                try {
+                    populationCollectService.collect(date);
+                } catch (Exception e) {
+                    log.warn("날짜 {} 수집 실패 (건너뜀): {}", date, e.getMessage());
+                }
+            }
+            log.info("초기 적재 완료");
+        } else {
+            log.info("dong_population_raw 데이터가 이미 존재합니다. 수집을 건너뜁니다.");
+        }
+
+        if (scoreRepository.count() == 0) {
+            log.info("찐로컬 지수 계산 시작: {}", latestDate);
+            localScoreCalculateService.calculateAndSave(latestDate);
+            log.info("초기 찐로컬 지수 계산 완료");
+        } else {
+            log.info("dong_local_score 데이터가 이미 존재합니다. 계산을 건너뜁니다.");
+        }
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/DongBoundaryImportService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/DongBoundaryImportService.java
@@ -31,13 +31,13 @@ public class DongBoundaryImportService {
 
         for (JsonNode feature : features) {
             JsonNode properties = feature.get("properties");
-            String admCd = properties.get("adm_cd").asText();
+            String admCd2 = properties.get("adm_cd2").asText();
 
             // 서울만 적재 (코드 앞 2자리 = 11)
-            if (!admCd.startsWith("11")) continue;
+            if (!admCd2.startsWith("11")) continue;
 
-            // 10자리 → 8자리 통일 (생활인구 API 기준)
-            String dongCode = admCd.length() > 8 ? admCd.substring(0, 8) : admCd;
+            // adm_cd2(10자리) 앞 8자리 = 생활인구 API ADSTRD_CODE_SE와 동일
+            String dongCode = admCd2.length() >= 8 ? admCd2.substring(0, 8) : admCd2;
             String dongName = properties.get("adm_nm").asText();
             String geomJson = objectMapper.writeValueAsString(feature.get("geometry"));
 

--- a/src/main/java/com/beyondtoursseoul/bts/service/score/LocalScoreCalculateService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/score/LocalScoreCalculateService.java
@@ -1,0 +1,172 @@
+package com.beyondtoursseoul.bts.service.score;
+
+import com.beyondtoursseoul.bts.domain.DongLocalScore;
+import com.beyondtoursseoul.bts.domain.DongPopulationRaw;
+import com.beyondtoursseoul.bts.repository.DongLocalScoreRepository;
+import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import tools.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LocalScoreCalculateService {
+
+    private final DongPopulationRawRepository rawRepository;
+    private final DongLocalScoreRepository scoreRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void calculateAndSave(LocalDate targetDate) {
+        log.info("찐로컬 지수 계산 시작: {}", targetDate);
+        LocalDate historyFrom = targetDate.minusDays(27);
+
+        for (TimeSlot slot : TimeSlot.values()) {
+            calculateForSlot(targetDate, historyFrom, slot);
+        }
+
+        log.info("찐로컬 지수 계산 완료: {}", targetDate);
+    }
+
+    private void calculateForSlot(LocalDate targetDate, LocalDate historyFrom, TimeSlot slot) {
+        List<DongPopulationRaw> currentList = rawRepository.findByDateAndTimeSlot(targetDate, slot.getCode());
+        if (currentList.isEmpty()) {
+            log.warn("데이터 없음 — time_slot: {}, date: {}", slot.getCode(), targetDate);
+            return;
+        }
+
+        // 과거 4주치 원시 데이터 (stability, repeat 계산용)
+        List<DongPopulationRaw> historyList = rawRepository.findByTimeSlotAndDateBetween(
+                slot.getCode(), historyFrom, targetDate);
+        Map<String, List<DongPopulationRaw>> historyByDong = historyList.stream()
+                .collect(Collectors.groupingBy(DongPopulationRaw::getDongCode));
+
+        // 행정동별 원시 지표 계산
+        Map<String, double[]> rawMetrics = new LinkedHashMap<>();
+        for (DongPopulationRaw current : currentList) {
+            String dongCode = current.getDongCode();
+            List<DongPopulationRaw> history = historyByDong.getOrDefault(dongCode, List.of(current));
+
+            double korean = current.getKoreanPop().doubleValue();
+            double foreign = current.getForeignPop().doubleValue();
+            double total = korean + foreign;
+
+            double localRatio     = total > 0 ? korean / total : 0.5;
+            double foreignPenalty = total > 0 ? foreign / total : 0.5;
+            double stability      = calculateStability(history);
+            double repeat         = calculateRepeat(history);
+
+            // [0]=local_ratio, [1]=stability, [2]=repeat, [3]=foreign_penalty
+            rawMetrics.put(dongCode, new double[]{localRatio, stability, repeat, foreignPenalty});
+        }
+
+        // MIN-MAX 정규화 (서울 전체 행정동 기준)
+        double[] mins = {Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE};
+        double[] maxs = {-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE};
+        for (double[] m : rawMetrics.values()) {
+            for (int i = 0; i < 4; i++) {
+                if (m[i] < mins[i]) mins[i] = m[i];
+                if (m[i] > maxs[i]) maxs[i] = m[i];
+            }
+        }
+
+        // 기존 점수 삭제 후 재계산
+        scoreRepository.deleteByDateAndTimeSlot(targetDate, slot.getCode());
+
+        List<DongLocalScore> scores = new ArrayList<>();
+        for (Map.Entry<String, double[]> entry : rawMetrics.entrySet()) {
+            double[] m = entry.getValue();
+            double[] norm = new double[4];
+            for (int i = 0; i < 4; i++) {
+                double range = maxs[i] - mins[i];
+                norm[i] = range > 1e-9 ? (m[i] - mins[i]) / range : 0.0;
+            }
+
+            double score = 0.3 * norm[0] + 0.3 * norm[1] + 0.3 * norm[2] - 0.1 * norm[3];
+            score = Math.max(0.0, Math.min(1.0, score));
+
+            scores.add(DongLocalScore.builder()
+                    .dongCode(entry.getKey())
+                    .date(targetDate)
+                    .timeSlot(slot.getCode())
+                    .score(BigDecimal.valueOf(score).setScale(2, RoundingMode.HALF_UP))
+                    .breakdownJson(buildBreakdown(slot.getCode(), m, norm))
+                    .build());
+        }
+
+        scoreRepository.saveAll(scores);
+        log.info("time_slot {} 저장 완료: {}개 행정동", slot.getCode(), scores.size());
+    }
+
+    // stability = 1 - |평일평균 - 주말평균| / MAX(평일평균, 주말평균)
+    private double calculateStability(List<DongPopulationRaw> history) {
+        List<Double> weekday = new ArrayList<>();
+        List<Double> weekend = new ArrayList<>();
+
+        for (DongPopulationRaw row : history) {
+            DayOfWeek dow = row.getDate().getDayOfWeek();
+            double pop = row.getKoreanPop().doubleValue();
+            if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY) {
+                weekend.add(pop);
+            } else {
+                weekday.add(pop);
+            }
+        }
+
+        if (weekday.isEmpty() || weekend.isEmpty()) return 1.0;
+
+        double wdAvg = weekday.stream().mapToDouble(d -> d).average().orElse(0);
+        double weAvg = weekend.stream().mapToDouble(d -> d).average().orElse(0);
+        double maxAvg = Math.max(wdAvg, weAvg);
+
+        return maxAvg > 0 ? 1.0 - Math.abs(wdAvg - weAvg) / maxAvg : 1.0;
+    }
+
+    // repeat = 1 / (1 + 변동계수)  변동계수 = 표준편차 / 평균
+    private double calculateRepeat(List<DongPopulationRaw> history) {
+        if (history.size() < 2) return 1.0;
+
+        double[] pops = history.stream()
+                .mapToDouble(r -> r.getKoreanPop().doubleValue())
+                .toArray();
+        double mean = Arrays.stream(pops).average().orElse(0);
+        if (mean < 1e-9) return 1.0;
+
+        double variance = Arrays.stream(pops).map(p -> Math.pow(p - mean, 2)).average().orElse(0);
+        double cv = Math.sqrt(variance) / mean;
+
+        return 1.0 / (1.0 + cv);
+    }
+
+    private String buildBreakdown(String timeSlot, double[] raw, double[] norm) {
+        try {
+            Map<String, Object> map = new LinkedHashMap<>();
+            map.put("time_slot", timeSlot);
+            map.put("local_ratio", round4(raw[0]));
+            map.put("stability", round4(raw[1]));
+            map.put("repeat", round4(raw[2]));
+            map.put("foreign_penalty", round4(raw[3]));
+            map.put("local_ratio_norm", round4(norm[0]));
+            map.put("stability_norm", round4(norm[1]));
+            map.put("repeat_norm", round4(norm[2]));
+            map.put("foreign_penalty_norm", round4(norm[3]));
+            return objectMapper.writeValueAsString(map);
+        } catch (Exception e) {
+            return "{}";
+        }
+    }
+
+    private double round4(double v) {
+        return Math.round(v * 10000.0) / 10000.0;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/score/PopulationCollectService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/score/PopulationCollectService.java
@@ -1,0 +1,119 @@
+package com.beyondtoursseoul.bts.service.score;
+
+import com.beyondtoursseoul.bts.dto.ForeignResidentApiResponseDto;
+import com.beyondtoursseoul.bts.dto.LocalResidentApiResponseDto;
+import com.beyondtoursseoul.bts.service.ForeignResidentApiService;
+import com.beyondtoursseoul.bts.service.LocalResidentApiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PopulationCollectService {
+
+    private final LocalResidentApiService localResidentApiService;
+    private final ForeignResidentApiService foreignResidentApiService;
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void collect(LocalDate date) {
+        log.info("생활인구 수집 시작: {}", date);
+
+        List<LocalResidentApiResponseDto.Row> koreanRows = localResidentApiService.fetchByDate(date);
+        List<ForeignResidentApiResponseDto.Row> foreignRows = foreignResidentApiService.fetchByDate(date);
+
+        Map<String, Map<TimeSlot, List<Double>>> koreanByDong = groupByDongAndSlot(koreanRows);
+        Map<String, Map<TimeSlot, List<Double>>> foreignByDong = groupByDongAndSlot(foreignRows);
+
+        Set<String> allDongs = new HashSet<>(koreanByDong.keySet());
+        allDongs.addAll(foreignByDong.keySet());
+
+        List<Object[]> batchArgs = new ArrayList<>();
+        for (String dongCode : allDongs) {
+            for (TimeSlot slot : TimeSlot.values()) {
+                double koreanAvg = average(koreanByDong.getOrDefault(dongCode, Map.of())
+                        .getOrDefault(slot, List.of()));
+                double foreignAvg = average(foreignByDong.getOrDefault(dongCode, Map.of())
+                        .getOrDefault(slot, List.of()));
+
+                batchArgs.add(new Object[]{
+                        dongCode,
+                        date,
+                        slot.getCode(),
+                        BigDecimal.valueOf(koreanAvg).setScale(4, RoundingMode.HALF_UP),
+                        BigDecimal.valueOf(foreignAvg).setScale(4, RoundingMode.HALF_UP)
+                });
+            }
+        }
+
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO dong_population_raw (dong_code, date, time_slot, korean_pop, foreign_pop) " +
+                "VALUES (?, ?, ?, ?, ?) " +
+                "ON CONFLICT (dong_code, date, time_slot) DO UPDATE SET " +
+                "korean_pop = EXCLUDED.korean_pop, foreign_pop = EXCLUDED.foreign_pop",
+                batchArgs
+        );
+
+        log.info("생활인구 저장 완료: {} ({} 행정동 × 5 슬롯)", date, allDongs.size());
+    }
+
+    private <T> Map<String, Map<TimeSlot, List<Double>>> groupByDongAndSlot(List<T> rows) {
+        Map<String, Map<TimeSlot, List<Double>>> result = new HashMap<>();
+        for (T row : rows) {
+            String dongCode;
+            String timeZone;
+            String totalPop;
+
+            if (row instanceof LocalResidentApiResponseDto.Row r) {
+                dongCode = r.getDongCode();
+                timeZone = r.getTimeZone();
+                totalPop = r.getTotalPopulation();
+            } else if (row instanceof ForeignResidentApiResponseDto.Row r) {
+                dongCode = r.getDongCode();
+                timeZone = r.getTimeZone();
+                totalPop = r.getTotalPopulation();
+            } else {
+                continue;
+            }
+
+            if (dongCode == null || timeZone == null) continue;
+
+            int hour;
+            try {
+                hour = Integer.parseInt(timeZone);
+            } catch (NumberFormatException e) {
+                continue;
+            }
+
+            TimeSlot.fromHour(hour).ifPresent(slot ->
+                    result.computeIfAbsent(dongCode, k -> new EnumMap<>(TimeSlot.class))
+                          .computeIfAbsent(slot, k -> new ArrayList<>())
+                          .add(parseDouble(totalPop))
+            );
+        }
+        return result;
+    }
+
+    private double parseDouble(String value) {
+        if (value == null || value.isBlank()) return 0.0;
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
+
+    private double average(List<Double> values) {
+        if (values.isEmpty()) return 0.0;
+        return values.stream().mapToDouble(d -> d).average().orElse(0.0);
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/score/TimeSlot.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/score/TimeSlot.java
@@ -1,0 +1,35 @@
+package com.beyondtoursseoul.bts.service.score;
+
+import java.util.Optional;
+
+public enum TimeSlot {
+
+    MORNING("morning", 6),
+    LUNCH("lunch", 11),
+    AFTERNOON("afternoon", 14),
+    EVENING("evening", 18),
+    NIGHT("night", 22);
+
+    private final String code;
+    private final int startHour; // dong_local_score.hour 에 저장되는 값
+
+    TimeSlot(String code, int startHour) {
+        this.code = code;
+        this.startHour = startHour;
+    }
+
+    public String getCode() { return code; }
+    public int getStartHour() { return startHour; }
+
+    // 06~10 → MORNING, 11~13 → LUNCH, 14~17 → AFTERNOON, 18~21 → EVENING
+    // 22,23,00,01,02 → NIGHT (같은 날짜 기준으로 묶음)
+    // 03,04,05 → 미사용
+    public static Optional<TimeSlot> fromHour(int hour) {
+        if (hour >= 6 && hour < 11)  return Optional.of(MORNING);
+        if (hour >= 11 && hour < 14) return Optional.of(LUNCH);
+        if (hour >= 14 && hour < 18) return Optional.of(AFTERNOON);
+        if (hour >= 18 && hour < 22) return Optional.of(EVENING);
+        if (hour >= 22 || hour < 3)  return Optional.of(NIGHT);
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
## 개요
>내국인/외국인 생활인구 데이터를 바탕으로 행정동별 찐로컬 지수를 계산하고 저장

## 변경 사항

> - DongPopulationRaw JPA Entity
> - DongPopulationRawRepository
> - PopulationCollectService — API 수집 → time_slot 집계 → dong_population_raw 저장
> - LocalScoreCalculateService — 4개 항목 계산 → MIN-MAX 정규화 → dong_local_score 저장
> - InitialDataLoader — 과거 4주치 bulk 적재 (최초 1회)


## 관련 이슈
close #28
