### PR TITLE
[FIX] Supabase 이메일 auth 응답 처리 및 예외처리 정리

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/beyondtoursseoul/bts/exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.beyondtoursseoul.bts.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RestClientResponseException.class)
+    public ResponseEntity<Map<String, Object>> handleRestClientResponseException(
+            RestClientResponseException e,
+            HttpServletRequest request
+    ) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now());
+        body.put("status", e.getStatusCode().value());
+        body.put("error", e.getStatusText());
+        body.put("message", e.getResponseBodyAsString());
+        body.put("path", request.getRequestURI());
+
+        return ResponseEntity.status(e.getStatusCode()).body(body);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalStateException(
+            IllegalStateException e,
+            HttpServletRequest request
+    ) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now());
+        body.put("status", 500);
+        body.put("error", "Internal Server Error");
+        body.put("message", e.getMessage());
+        body.put("path", request.getRequestURI());
+        return ResponseEntity.internalServerError().body(body);
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/auth/SupabaseAuthService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/auth/SupabaseAuthService.java
@@ -7,6 +7,8 @@ import com.beyondtoursseoul.bts.dto.auth.MeResponse;
 import com.beyondtoursseoul.bts.dto.auth.SignupRequest;
 import com.beyondtoursseoul.bts.repository.ProfileRepository;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import java.util.UUID;
 public class SupabaseAuthService implements AuthService {
 
     private final ProfileRepository profileRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private final RestClient restClient = RestClient.create();
 
     @Value("${SUPABASE_URL}")
@@ -42,9 +45,50 @@ public class SupabaseAuthService implements AuthService {
                 .retrieve()
                 .body(String.class);
 
-        System.out.println("signup raw response = " + rawResponse);
+        try {
+            JsonNode root = objectMapper.readTree(rawResponse);
 
-        throw new IllegalStateException(rawResponse);
+            if (root.isMissingNode() || root.isNull()) {
+                throw new IllegalStateException("회원가입 응답이 올바르지 않습니다.");
+            }
+
+            String accessToken = root.path("access_token").isMissingNode() || root.path("access_token").isNull()
+                    ? null
+                    : root.path("access_token").asText();
+
+            String refreshToken = root.path("refresh_token").isMissingNode() || root.path("refresh_token").isNull()
+                    ? null
+                    : root.path("refresh_token").asText();
+
+            String tokenType = root.path("token_type").isMissingNode() || root.path("token_type").isNull()
+                    ? null
+                    : root.path("token_type").asText();
+
+            Long expiresIn = root.path("expires_in").isMissingNode() || root.path("expires_in").isNull()
+                    ? null
+                    : root.path("expires_in").asLong();
+
+            String userId = root.path("id").asText(null);
+            String email = root.path("email").asText(null);
+
+            String message = accessToken == null
+                    ? "회원가입 완료. 이메일 인증 후 로그인하세요."
+                    : "회원가입 및 로그인 완료";
+
+            return new AuthResponse(
+                    accessToken,
+                    refreshToken,
+                    tokenType,
+                    expiresIn,
+                    userId,
+                    email,
+                    message
+            );
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("회원가입 응답 파싱에 실패했습니다.", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
## 개요
Google 로그인 연동 전에 이메일 기반 Supabase auth 흐름을 마무리했습니다.

## 변경 사항
- `signup()` 디버깅 코드 제거 및 응답 파싱 로직 정리
- 실제 Supabase 회원가입 응답 구조에 맞게 회원가입 응답 처리 수정
- `GlobalExceptionHandler` 추가로 Supabase 예외 응답 정리
- `signup`, `login`, `me` 흐름 재확인

## 테스트
- [x] `POST /api/v1/auth/signup`
- [x] `POST /api/v1/auth/login`
- [x] `GET /api/v1/auth/me`
- [x] `compileJava`

## 관련 이슈
close #32
