### PR TITLE
[FEAT] 매일 새벽 찐로컬 지수 자동 계산 스케줄러 추가

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
+++ b/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
@@ -1,0 +1,42 @@
+package com.beyondtoursseoul.bts.scheduler;
+
+import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
+import com.beyondtoursseoul.bts.service.LocalResidentApiService;
+import com.beyondtoursseoul.bts.service.score.LocalScoreCalculateService;
+import com.beyondtoursseoul.bts.service.score.PopulationCollectService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyScoreScheduler {
+
+    private final LocalResidentApiService localResidentApiService;
+    private final PopulationCollectService populationCollectService;
+    private final LocalScoreCalculateService localScoreCalculateService;
+    private final DongPopulationRawRepository rawRepository;
+
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
+    public void run() {
+        log.info("[DailyScoreScheduler] 시작");
+        try {
+            LocalDate targetDate = localResidentApiService.findLatestAvailableDate();
+
+            if (rawRepository.existsByDate(targetDate)) {
+                log.info("[DailyScoreScheduler] {} 데이터 이미 존재 — 스킵", targetDate);
+                return;
+            }
+
+            populationCollectService.collect(targetDate);
+            localScoreCalculateService.calculateAndSave(targetDate);
+            log.info("[DailyScoreScheduler] 완료: {}", targetDate);
+        } catch (Exception e) {
+            log.error("[DailyScoreScheduler] 실패 — {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/test/java/com/beyondtoursseoul/bts/scheduler/DailyScoreSchedulerTest.java
+++ b/src/test/java/com/beyondtoursseoul/bts/scheduler/DailyScoreSchedulerTest.java
@@ -1,0 +1,76 @@
+package com.beyondtoursseoul.bts.scheduler;
+
+import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
+import com.beyondtoursseoul.bts.service.LocalResidentApiService;
+import com.beyondtoursseoul.bts.service.score.LocalScoreCalculateService;
+import com.beyondtoursseoul.bts.service.score.PopulationCollectService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DailyScoreSchedulerTest {
+
+    @Mock LocalResidentApiService localResidentApiService;
+    @Mock PopulationCollectService populationCollectService;
+    @Mock LocalScoreCalculateService localScoreCalculateService;
+    @Mock DongPopulationRawRepository rawRepository;
+
+    @InjectMocks DailyScoreScheduler scheduler;
+
+    @Test
+    void 신규_날짜면_수집과_계산이_순서대로_실행된다() {
+        LocalDate targetDate = LocalDate.of(2026, 4, 28);
+        when(localResidentApiService.findLatestAvailableDate()).thenReturn(targetDate);
+        when(rawRepository.existsByDate(targetDate)).thenReturn(false);
+
+        scheduler.run();
+
+        InOrder order = inOrder(populationCollectService, localScoreCalculateService);
+        order.verify(populationCollectService).collect(targetDate);
+        order.verify(localScoreCalculateService).calculateAndSave(targetDate);
+    }
+
+    @Test
+    void 이미_수집된_날짜면_수집과_계산을_건너뛴다() {
+        LocalDate targetDate = LocalDate.of(2026, 4, 28);
+        when(localResidentApiService.findLatestAvailableDate()).thenReturn(targetDate);
+        when(rawRepository.existsByDate(targetDate)).thenReturn(true);
+
+        scheduler.run();
+
+        verify(populationCollectService, never()).collect(any());
+        verify(localScoreCalculateService, never()).calculateAndSave(any());
+    }
+
+    @Test
+    void API_날짜_조회_실패시_앱이_죽지_않는다() {
+        when(localResidentApiService.findLatestAvailableDate())
+                .thenThrow(new IllegalStateException("최근 7일 내 데이터 없음"));
+
+        assertDoesNotThrow(() -> scheduler.run());
+
+        verify(populationCollectService, never()).collect(any());
+        verify(localScoreCalculateService, never()).calculateAndSave(any());
+    }
+
+    @Test
+    void 수집_실패시_계산을_실행하지_않고_앱이_죽지_않는다() {
+        LocalDate targetDate = LocalDate.of(2026, 4, 28);
+        when(localResidentApiService.findLatestAvailableDate()).thenReturn(targetDate);
+        when(rawRepository.existsByDate(targetDate)).thenReturn(false);
+        doThrow(new RuntimeException("API 오류")).when(populationCollectService).collect(targetDate);
+
+        assertDoesNotThrow(() -> scheduler.run());
+
+        verify(localScoreCalculateService, never()).calculateAndSave(any());
+    }
+}


### PR DESCRIPTION
## 개요

> 매일 새벽 어제 날짜의 생활인구 데이터를 수집하고 찐로컬 지수를 계산하여
> dong_local_score 테이블을 최신 상태로 유지한다.

## 변경 사항

> - DailyScoreScheduler 클래스 생성
>   - 매일 01:00 (KST) cron 실행
>   - PopulationCollectService.collect(어제날짜) 호출
>   - LocalScoreCalculateService.calculateAndSave(어제날짜) 호출
>   -예외 발생 시 로그만 남기고 다음 날 재시도 (앱 종료 X)

## 테스트

- [x] API_날짜_조회_실패시_앱이_죽지_않는다()                                                                                              
- [x] 수집_실패시_계산을_실행하지_않고_앱이_죽지_않는다()         
- [x] 신규_날짜면_수집과_계산이_순서대로_실행된다()                                                                                          
- [x] 이미_수집된_날짜면_수집과_계산을_건너뛴다()

## 관련 이슈
close #40 
