### PR TITLE
[FEAT] 관광지-> 행정동 dong_code 매핑

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/runner/InitialDataLoader.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/InitialDataLoader.java
@@ -3,6 +3,7 @@ package com.beyondtoursseoul.bts.runner;
 import com.beyondtoursseoul.bts.repository.AttractionRepository;
 import com.beyondtoursseoul.bts.repository.DongLocalScoreRepository;
 import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
+import com.beyondtoursseoul.bts.service.AttractionMappingService;
 import com.beyondtoursseoul.bts.service.LocalResidentApiService;
 import com.beyondtoursseoul.bts.service.TourApiService;
 import com.beyondtoursseoul.bts.service.score.LocalScoreCalculateService;
@@ -25,6 +26,7 @@ public class InitialDataLoader implements ApplicationRunner {
     private final DongPopulationRawRepository rawRepository;
     private final DongLocalScoreRepository scoreRepository;
     private final AttractionRepository attractionRepository;
+    private final AttractionMappingService attractionMappingService;
     private final PopulationCollectService populationCollectService;
     private final LocalScoreCalculateService localScoreCalculateService;
     private final LocalResidentApiService localResidentApiService;
@@ -67,6 +69,17 @@ public class InitialDataLoader implements ApplicationRunner {
             }
         } else {
             log.info("attraction 데이터가 이미 존재합니다. 수집을 건너뜁니다.");
+        }
+
+        if (attractionMappingService.countNullDongCode() > 0) {
+            log.info("관광지 행정동 매핑 시작");
+            try {
+                attractionMappingService.mapDongCodes();
+            } catch (Exception e) {
+                log.warn("관광지 행정동 매핑 실패 (건너뜀): {}", e.getMessage());
+            }
+        } else {
+            log.info("관광지 행정동 매핑이 이미 완료되어 있습니다.");
         }
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionMappingService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionMappingService.java
@@ -1,0 +1,75 @@
+package com.beyondtoursseoul.bts.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AttractionMappingService {
+
+    private static final int FALLBACK_RADIUS_METERS = 500;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void mapDongCodes() {
+        int total = countTotal();
+        log.info("[매핑] 시작 — 전체 관광지: {}건", total);
+
+        int contained = applyContains();
+        log.info("[매핑] ST_Contains 매핑: {}건", contained);
+
+        int fallback = applyDWithinFallback();
+        log.info("[매핑] ST_DWithin({}m) fallback 매핑: {}건", FALLBACK_RADIUS_METERS, fallback);
+
+        int remaining = countNullDongCode();
+        log.info("[매핑] 완료 — 매핑률: {}/{} (미매핑: {}건)",
+                total - remaining, total, remaining);
+    }
+
+    // ST_Contains: 관광지 좌표가 행정동 폴리곤 내부에 포함되는 경우
+    private int applyContains() {
+        return jdbcTemplate.update("""
+                UPDATE attraction a
+                SET dong_code = d.dong_code
+                FROM dong_boundary d
+                WHERE ST_Contains(d.geom, a.geom)
+                  AND a.dong_code IS NULL
+                """);
+    }
+
+    // ST_DWithin fallback: 경계선 위 또는 좌표 오차로 누락된 항목을 가장 가까운 행정동으로 매핑
+    private int applyDWithinFallback() {
+        return jdbcTemplate.update("""
+                UPDATE attraction a
+                SET dong_code = (
+                    SELECT d.dong_code
+                    FROM dong_boundary d
+                    WHERE ST_DWithin(a.geom::geography, d.geom::geography, ?)
+                    ORDER BY ST_Distance(a.geom::geography, d.geom::geography)
+                    LIMIT 1
+                )
+                WHERE a.dong_code IS NULL
+                  AND EXISTS (
+                      SELECT 1 FROM dong_boundary d
+                      WHERE ST_DWithin(a.geom::geography, d.geom::geography, ?)
+                  )
+                """, FALLBACK_RADIUS_METERS, FALLBACK_RADIUS_METERS);
+    }
+
+    public int countNullDongCode() {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM attraction WHERE dong_code IS NULL", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    private int countTotal() {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM attraction", Integer.class);
+        return count != null ? count : 0;
+    }
+}

--- a/src/test/java/com/beyondtoursseoul/bts/service/AttractionMappingServiceTest.java
+++ b/src/test/java/com/beyondtoursseoul/bts/service/AttractionMappingServiceTest.java
@@ -1,0 +1,45 @@
+package com.beyondtoursseoul.bts.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class AttractionMappingServiceTest {
+
+    @Autowired
+    private AttractionMappingService attractionMappingService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void 매핑률이_99퍼센트_이상이다() {
+        // InitialDataLoader가 앱 기동 시 이미 매핑 완료 → 결과 검증
+        int total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM attraction", Integer.class);
+        int nullCount = attractionMappingService.countNullDongCode();
+        int mappedCount = total - nullCount;
+        double mappingRate = (double) mappedCount / total * 100;
+
+        System.out.printf("매핑률: %.2f%% (%d / %d, 미매핑: %d건)%n",
+                mappingRate, mappedCount, total, nullCount);
+
+        assertThat(mappingRate).isGreaterThanOrEqualTo(99.0);
+    }
+
+    @Test
+    void mapDongCodes_재실행시_멱등성이_보장된다() {
+        int beforeNull = attractionMappingService.countNullDongCode();
+
+        // 이미 매핑된 상태에서 재실행해도 결과가 바뀌지 않아야 함
+        attractionMappingService.mapDongCodes();
+
+        int afterNull = attractionMappingService.countNullDongCode();
+        System.out.printf("재실행 전 미매핑: %d건, 재실행 후 미매핑: %d건%n", beforeNull, afterNull);
+
+        assertThat(afterNull).isEqualTo(beforeNull);
+    }
+}


### PR DESCRIPTION
## 개요
TourAPI로 수집한 관광지(점)를 행정동 경계(폴리곤)와 공간 연산으로 매칭하여
attraction.dong_code를 채운다. dong_code가 있어야 찐로컬 지수와 연결 가능.

1차: ST_Contains로 폴리곤 내부 점 매칭
2차: 1차에서 누락된 항목을 ST_DWithin(500m)으로 가장 가까운 행정동 fallback

## 변경 사항

- AttractionMappingService 작성
  - ST_Contains로 dong_code 일괄 업데이트
  - dong_code IS NULL 남은 항목에 ST_DWithin(500m) fallback 적용
- InitialDataLoader에서 attraction 수집 직후 매핑 호출
- AttractionMappingServiceTest 작성
  - 매핑 후 dong_code NULL 개수 확인
  - 전체 매핑률 로그 출력


## 관련 이슈
close #45
