### PR TITLE
[FEAT] 백엔드 Google 로그인 시작 API 구현

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/config/SecurityConfig.java
+++ b/src/main/java/com/beyondtoursseoul/bts/config/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login")
                         .permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/auth/google")
+                        .permitAll()
                         // 서버 상태 확인용 경로는 공개한다.
                         .requestMatchers(HttpMethod.GET, "/health")
                         .permitAll()

--- a/src/main/java/com/beyondtoursseoul/bts/controller/AuthController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/AuthController.java
@@ -6,9 +6,12 @@ import com.beyondtoursseoul.bts.dto.auth.MeResponse;
 import com.beyondtoursseoul.bts.dto.auth.SignupRequest;
 import com.beyondtoursseoul.bts.service.auth.AuthService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -24,6 +27,15 @@ public class AuthController {
     @PostMapping("/login")
     public AuthResponse login(@RequestBody LoginRequest request) {
         return authService.login(request);
+    }
+
+    @GetMapping("/google")
+    public ResponseEntity<Void> googleLogin() {
+        URI googleLoginUrl = authService.getGoogleLoginUrl();
+
+        return ResponseEntity.status(302)
+                .location(googleLoginUrl)
+                .build();
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/beyondtoursseoul/bts/service/auth/AuthService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/auth/AuthService.java
@@ -6,11 +6,15 @@ import com.beyondtoursseoul.bts.dto.auth.MeResponse;
 import com.beyondtoursseoul.bts.dto.auth.SignupRequest;
 import org.springframework.security.oauth2.jwt.Jwt;
 
+import java.net.URI;
+
 public interface AuthService {
 
     AuthResponse signup(SignupRequest request);
 
     AuthResponse login(LoginRequest request);
+
+    URI getGoogleLoginUrl();
 
     MeResponse me(Jwt jwt);
 }

--- a/src/main/java/com/beyondtoursseoul/bts/service/auth/SupabaseAuthService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/auth/SupabaseAuthService.java
@@ -16,7 +16,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
 import java.util.UUID;
 
 @Service
@@ -32,6 +34,10 @@ public class SupabaseAuthService implements AuthService {
 
     @Value("${SUPABASE_PUBLISHABLE_KEY}")
     private String publishableKey;
+
+    // Google 로그인 완료 후 프론트가 다시 돌아올 callback URL이다.
+    @Value("${FRONTEND_AUTH_CALLBACK_URL}")
+    private String frontendAuthCallbackUrl;
 
 //
     @Override
@@ -114,6 +120,17 @@ public class SupabaseAuthService implements AuthService {
                 result.getUser().getEmail(),
                 "로그인 성공"
         );
+    }
+
+    @Override
+    public URI getGoogleLoginUrl() {
+        return UriComponentsBuilder.fromUriString(supabaseUrl)
+                .path("/auth/v1/authorize")
+                .queryParam("provider", "google")
+                .queryParam("redirect_to", frontendAuthCallbackUrl)
+                .build()
+                .encode()
+                .toUri();
     }
 
     @Override


### PR DESCRIPTION
## 개요
백엔드 주도 Google 로그인 시작 API를 구현

## 변경 사항
- Google 로그인 시작 URL 생성 로직 추가
- `GET /api/v1/auth/google` 엔드포인트 추가
- 공개 경로 및 callback 설정 반영

## 테스트
- [x] Google 로그인 시작 redirect 동작 확인

## 관련 이슈
close #37
