### PR TITLE
[FEAT] 문화행사데이터 관련 Entity, Repository, Controller, Service, Dto 생성

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/controller/tour/TourController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/tour/TourController.java
@@ -1,0 +1,51 @@
+package com.beyondtoursseoul.bts.controller.tour;
+
+import com.beyondtoursseoul.bts.domain.tour.TourLanguage;
+import com.beyondtoursseoul.bts.dto.tour.TourApiEventItemDto;
+import com.beyondtoursseoul.bts.dto.tour.TourApiResponseDto;
+import com.beyondtoursseoul.bts.service.tour.TourApiService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@Tag(name = "Tour API", description = "관광공사 데이터 연동 및 조회 API")
+@RestController
+@RequestMapping("/api/v1/tour")
+@RequiredArgsConstructor
+public class TourController {
+
+    private final TourApiService tourApiService;
+
+    /**
+     * 1. API 호출 결과 DTO로 즉시 확인 (DB 저장 X)
+     */
+    @Operation(summary = "관광공사 API 원본 데이터 확인", description = "DB에 저장하지 않고 API 결과만 DTO로 반환합니다.")
+    @GetMapping("/test/fetch")
+    public ResponseEntity<TourApiResponseDto<TourApiEventItemDto>> fetchTest(
+            @RequestParam(defaultValue = "KOR") TourLanguage lang) {
+
+        TourApiResponseDto<TourApiEventItemDto> result = tourApiService.getRawFestivals(lang);
+        log.info("문화/행사/축제 데이터 조회 완료: {}건, language: {}", result.getResponse().getBody().getTotalCount(), lang);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 2. API 호출 후 DB 동기화 실행
+     */
+    @Operation(summary = "관광공사 데이터 DB 동기화 실행 (임의 실행 X)", description = "API 데이터를 긁어와서 우리 DB에 저장/업데이트합니다.")
+    @GetMapping("/test/sync")
+    public ResponseEntity<String> syncTest(
+            @RequestParam(defaultValue = "KOR") TourLanguage lang) {
+
+        try {
+            tourApiService.syncFestivals(lang);
+            return ResponseEntity.ok("Successfully synced " + lang + " data to database.");
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body("Sync failed: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/cultural/CulturalEvent.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/cultural/CulturalEvent.java
@@ -1,0 +1,121 @@
+package com.beyondtoursseoul.bts.domain.cultural;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "cultural_event")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CulturalEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 비짓서울 API의 기준 CID (중복 방지 및 업데이트 기준)
+    @Column(name = "master_cid", unique = true, nullable = false, length = 50)
+    private String masterCid;
+
+    // 카테고리 코드 (예: Cg1x6l1)
+    @Column(name = "category_code", length = 50)
+    private String categoryCode;
+
+    // 카테고리 경로 (예: 문화관광 > 전시시설)
+    @Column(name = "category_depth")
+    private String categoryDepth;
+
+    // 대표 이미지 URL
+    @Column(name = "main_img_url", length = 500)
+    private String mainImgUrl;
+
+    // 행사 시작일
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    // 행사 종료일
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    // 위도 (map_position_y)
+    @Column(nullable = false)
+    private Double latitude;
+
+    // 경도 (map_position_x)
+    @Column(nullable = false)
+    private Double longitude;
+
+    // 전화번호
+    @Column(name = "tel_no", length = 50)
+    private String telNo;
+
+    // 홈페이지 URL
+    @Column(name = "homepage_url", length = 1000)
+    private String homepageUrl;
+
+    // 무료 여부 (trrsrt_use_chrge가 'F'면 true, 'C'면 false)
+    @Column(name = "is_free")
+    private Boolean isFree;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+
+    @OneToMany(mappedBy = "culturalEvent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CulturalEventTranslation> translations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "culturalEvent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CulturalEventImage> images = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = OffsetDateTime.now();
+    }
+
+    @Builder
+    public CulturalEvent(String masterCid, String categoryCode, String categoryDepth, String mainImgUrl,
+                        LocalDate startDate, LocalDate endDate, Double latitude, Double longitude,
+                        String telNo, String homepageUrl, Boolean isFree) {
+        this.masterCid = masterCid;
+        this.categoryCode = categoryCode;
+        this.categoryDepth = categoryDepth;
+        this.mainImgUrl = mainImgUrl;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.telNo = telNo;
+        this.homepageUrl = homepageUrl;
+        this.isFree = isFree;
+    }
+
+    public void update(String categoryCode, String categoryDepth, String mainImgUrl,
+                       LocalDate startDate, LocalDate endDate, Double latitude, Double longitude,
+                       String telNo, String homepageUrl, Boolean isFree) {
+        this.categoryCode = categoryCode;
+        this.categoryDepth = categoryDepth;
+        this.mainImgUrl = mainImgUrl;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.telNo = telNo;
+        this.homepageUrl = homepageUrl;
+        this.isFree = isFree;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/cultural/CulturalEventImage.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/cultural/CulturalEventImage.java
@@ -1,0 +1,31 @@
+package com.beyondtoursseoul.bts.domain.cultural;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cultural_event_image")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CulturalEventImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cultural_event_id")
+    private CulturalEvent culturalEvent;
+
+    @Column(name = "image_url", nullable = false, length = 1000)
+    private String imageUrl;
+
+    @Builder
+    public CulturalEventImage(CulturalEvent culturalEvent, String imageUrl) {
+        this.culturalEvent = culturalEvent;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/cultural/CulturalEventTranslation.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/cultural/CulturalEventTranslation.java
@@ -1,0 +1,84 @@
+package com.beyondtoursseoul.bts.domain.cultural;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cultural_event_translation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CulturalEventTranslation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cultural_event_id")
+    private CulturalEvent culturalEvent;
+
+    // 해당 언어 버전의 CID
+    @Column(nullable = false, length = 50)
+    private String cid;
+
+    // 언어 코드 (ko, en, ja, zh-CN 등)
+    @Column(name = "lang_code", nullable = false, length = 10)
+    private String langCode;
+
+    // 제목 (post_sj)
+    @Column(nullable = false, length = 500)
+    private String title;
+
+    // 요약 설명 (sumry)
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
+    // 상세 설명 (post_desc) - HTML 포함 가능하므로 LONGTEXT
+    @Column(name = "post_desc", columnDefinition = "LONGTEXT")
+    private String description;
+
+    // 주소 (new_adres 또는 adres)
+    @Column(length = 500)
+    private String address;
+
+    // 이용 시간 (cmmn_use_time)
+    @Column(name = "use_time", columnDefinition = "TEXT")
+    private String useTime;
+
+    // 이용 요금 안내 (trrsrt_use_chrge_guidance)
+    @Column(name = "fee_info", columnDefinition = "TEXT")
+    private String feeInfo;
+
+    // 휴무일 (closed_days)
+    @Column(name = "closed_days")
+    private String closedDays;
+
+    // 교통 정보 (subway_info)
+    @Column(name = "traffic_info", columnDefinition = "TEXT")
+    private String trafficInfo;
+
+    // 태그 (쉼표 구분 문자열)
+    @Column(columnDefinition = "TEXT")
+    private String tags;
+
+    @Builder
+    public CulturalEventTranslation(CulturalEvent culturalEvent, String cid, String langCode, String title,
+                                   String summary, String description, String address, String useTime,
+                                   String feeInfo, String closedDays, String trafficInfo, String tags) {
+        this.culturalEvent = culturalEvent;
+        this.cid = cid;
+        this.langCode = langCode;
+        this.title = title;
+        this.summary = summary;
+        this.description = description;
+        this.address = address;
+        this.useTime = useTime;
+        this.feeInfo = feeInfo;
+        this.closedDays = closedDays;
+        this.trafficInfo = trafficInfo;
+        this.tags = tags;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/tour/TourApiEvent.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/tour/TourApiEvent.java
@@ -1,0 +1,64 @@
+package com.beyondtoursseoul.bts.domain.tour;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "tour_api_event")
+public class TourApiEvent {
+
+    @Id
+    @Column(name = "content_id")
+    private Long contentId; // 관광공사 고유 ID
+
+    @Column(name = "content_type_id")
+    private Long contentTypeId; // 축제/행사 타입 코드
+
+    @Column(name = "first_image")
+    private String firstImage;
+
+    @Column(name = "first_image2")
+    private String firstImage2;
+
+    @Column(name = "map_x")
+    private Double mapX;
+
+    @Column(name = "map_y")
+    private Double mapY;
+
+    @Column(name = "tel")
+    private String tel;
+
+    @Column(name = "zipcode")
+    private String zipCode;
+
+    @Column(name = "event_start_date")
+    private String eventStartDate; // YYYYMMDD
+
+    @Column(name = "event_end_date")
+    private String eventEndDate; // YYYYMMDD
+
+    @Column(name = "area_code")
+    private String areaCode;
+
+    @Column(name = "sigungu_code")
+    private String sigunguCode;
+
+    @Column(name = "modified_time")
+    private String modifiedTime; // API 제공 수정일시
+
+    @Column(name = "last_sync_time")
+    private LocalDateTime lastSyncTime; // 우리 DB 동기화 일시
+
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<TourApiEventTranslation> translations = new ArrayList<>();
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/tour/TourApiEventTranslation.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/tour/TourApiEventTranslation.java
@@ -1,0 +1,41 @@
+package com.beyondtoursseoul.bts.domain.tour;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(
+    name = "tour_api_event_translation",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"content_id", "language"})
+    }
+)
+public class TourApiEventTranslation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private TourApiEvent event;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "language")
+    private TourLanguage language;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "address")
+    private String address;
+
+    @Lob
+    @Column(name = "overview", columnDefinition = "TEXT")
+    private String overview;
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/tour/TourLanguage.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/tour/TourLanguage.java
@@ -1,0 +1,22 @@
+package com.beyondtoursseoul.bts.domain.tour;
+
+import lombok.Getter;
+
+@Getter
+public enum TourLanguage {
+    KOR("KorService2"),
+    ENG("EngService2"),
+    JPN("JpnService2"),
+    CHS("ChsService2"), // 중국어 간체
+    CHT("ChtService2"), // 중국어 번체
+    GER("GerService2"),
+    FRE("FreService2"),
+    SPN("SpnService2"),
+    RUS("RusService2");
+
+    private final String serviceName;
+
+    TourLanguage(String serviceName) {
+        this.serviceName = serviceName;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/tour/TourLanguage.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/tour/TourLanguage.java
@@ -8,11 +8,11 @@ public enum TourLanguage {
     ENG("EngService2"),
     JPN("JpnService2"),
     CHS("ChsService2"), // 중국어 간체
-    CHT("ChtService2"), // 중국어 번체
-    GER("GerService2"),
-    FRE("FreService2"),
-    SPN("SpnService2"),
-    RUS("RusService2");
+    CHT("ChtService2"); // 중국어 번체
+//    GER("GerService2"),
+//    FRE("FreService2"),
+//    SPN("SpnService2"),
+//    RUS("RusService2");
 
     private final String serviceName;
 

--- a/src/main/java/com/beyondtoursseoul/bts/dto/tour/TourApiEventItemDto.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/tour/TourApiEventItemDto.java
@@ -1,0 +1,82 @@
+package com.beyondtoursseoul.bts.dto.tour;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "관광공사 API 행사/축제 아이템 정보")
+public class TourApiEventItemDto {
+
+    @JsonAlias("contentid")
+    @Schema(description = "콘텐츠 고유 ID", example = "3310483")
+    private Long contentId;
+
+    @JsonAlias("contenttypeid")
+    @Schema(description = "콘텐츠 타입 ID (축제/행사: 15)", example = "15")
+    private Long contentTypeId;
+
+    @JsonAlias("title")
+    @Schema(description = "행사 명칭", example = "어린이·가족 예술축제")
+    private String title;
+
+    @JsonAlias("addr1")
+    @Schema(description = "주소", example = "서울특별시 양천구 남부순환로64길 2")
+    private String addr1;
+
+    @JsonAlias("addr2")
+    @Schema(description = "상세 주소 (장소명 등)", example = "서울문화예술교육센터 양천")
+    private String addr2;
+
+    @JsonAlias("zipcode")
+    @Schema(description = "우편번호", example = "07916")
+    private String zipCode;
+
+    @JsonAlias("firstimage")
+    @Schema(description = "대표 이미지 URL (원본)", example = "https://tong.visitkorea.or.kr/cms/resource/18/4012118_image2_1.jpg")
+    private String firstImage;
+
+    @JsonAlias("firstimage2")
+    @Schema(description = "대표 이미지 URL (썸네일)", example = "https://tong.visitkorea.or.kr/cms/resource/18/4012118_image3_1.jpg")
+    private String firstImage2;
+
+    @JsonAlias("mapx")
+    @Schema(description = "GPS 경도 (Longitude)", example = "126.83214572562274")
+    private Double mapX;
+
+    @JsonAlias("mapy")
+    @Schema(description = "GPS 위도 (Latitude)", example = "37.52822008764788")
+    private Double mapY;
+
+    @JsonAlias("tel")
+    @Schema(description = "전화번호", example = "02-2697-0014")
+    private String tel;
+
+    @JsonAlias("eventstartdate")
+    @Schema(description = "행사 시작일 (YYYYMMDD)", example = "20260502")
+    private String eventStartDate;
+
+    @JsonAlias("eventenddate")
+    @Schema(description = "행사 종료일 (YYYYMMDD)", example = "20260503")
+    private String eventEndDate;
+
+    @JsonAlias("areacode")
+    @Schema(description = "지역 코드", example = "1")
+    private String areaCode;
+
+    @JsonAlias("sigungucode")
+    @Schema(description = "시군구 코드", example = "1")
+    private String sigunguCode;
+
+    @JsonAlias("lDongRegnCd")
+    @Schema(description = "법정동 지역코드 (서울: 11)", example = "11")
+    private String localRegionCode;
+
+    @JsonAlias("lDongSignguCd")
+    @Schema(description = "법정동 시군구코드", example = "470")
+    private String localSigunguCode;
+
+    @JsonAlias("modifiedtime")
+    @Schema(description = "최종 수정 시간 (YYYYMMDDHHMMSS)", example = "20260414180928")
+    private String modifiedTime;
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/tour/TourApiResponseDto.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/tour/TourApiResponseDto.java
@@ -1,0 +1,42 @@
+package com.beyondtoursseoul.bts.dto.tour;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@Schema(description = "관광공사 API 공통 응답 래퍼")
+public class TourApiResponseDto<T> {
+
+    private Response<T> response;
+
+    @Data
+    public static class Response<T> {
+        private Header header;
+        private Body<T> body;
+    }
+
+    @Data
+    public static class Header {
+        @Schema(description = "결과 코드 (0000: 성공)", example = "0000")
+        private String resultCode;
+        @Schema(description = "결과 메시지", example = "OK")
+        private String resultMsg;
+    }
+
+    @Data
+    public static class Body<T> {
+        private Items<T> items;
+        @Schema(description = "한 페이지 결과 수", example = "10")
+        private int numOfRows;
+        @Schema(description = "페이지 번호", example = "1")
+        private int pageNo;
+        @Schema(description = "전체 결과 수", example = "125")
+        private int totalCount;
+    }
+
+    @Data
+    public static class Items<T> {
+        private List<T> item;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/repository/tour/TourApiEventRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/tour/TourApiEventRepository.java
@@ -1,0 +1,10 @@
+package com.beyondtoursseoul.bts.repository.tour;
+
+import com.beyondtoursseoul.bts.domain.tour.TourApiEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TourApiEventRepository extends JpaRepository<TourApiEvent, Long> {
+
+}

--- a/src/main/java/com/beyondtoursseoul/bts/repository/tour/TourApiEventTranslationRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/tour/TourApiEventTranslationRepository.java
@@ -1,0 +1,16 @@
+package com.beyondtoursseoul.bts.repository.tour;
+
+import com.beyondtoursseoul.bts.domain.tour.TourApiEvent;
+import com.beyondtoursseoul.bts.domain.tour.TourApiEventTranslation;
+import com.beyondtoursseoul.bts.domain.tour.TourLanguage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TourApiEventTranslationRepository extends JpaRepository<TourApiEventTranslation, Long> {
+
+    // 특정 행사, 언어에 해당하는 번역 데이터가 있는지 확인
+    Optional<TourApiEventTranslation> findByEventAndLanguage(TourApiEvent event, TourLanguage language);
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/tour/TourApiService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/tour/TourApiService.java
@@ -1,0 +1,120 @@
+package com.beyondtoursseoul.bts.service.tour;
+
+import com.beyondtoursseoul.bts.domain.tour.TourApiEvent;
+import com.beyondtoursseoul.bts.domain.tour.TourApiEventTranslation;
+import com.beyondtoursseoul.bts.domain.tour.TourLanguage;
+import com.beyondtoursseoul.bts.dto.tour.TourApiEventItemDto;
+import com.beyondtoursseoul.bts.dto.tour.TourApiResponseDto;
+import com.beyondtoursseoul.bts.repository.tour.TourApiEventRepository;
+import com.beyondtoursseoul.bts.repository.tour.TourApiEventTranslationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Service
+public class TourApiService {
+
+    private final TourApiEventRepository eventRepository;
+    private final TourApiEventTranslationRepository translationRepository;
+    private final RestClient restClient;
+
+    @Value("${public.data.api.key}")
+    private String tourApiKey;
+
+    private static final String PUBLIC_DATA_API_URL =
+            "https://apis.data.go.kr/B551011/";
+
+    public TourApiService(TourApiEventRepository eventRepository, TourApiEventTranslationRepository translationRepository) {
+        this.eventRepository = eventRepository;
+        this.translationRepository = translationRepository;
+        this.restClient = RestClient.builder().baseUrl(PUBLIC_DATA_API_URL).build();
+    }
+
+
+    @Transactional
+    public void syncFestivals(TourLanguage lang) {
+        log.info("서울 축제/행사 정보 sync, language: {}", lang);
+
+        TourApiResponseDto<TourApiEventItemDto> response = fetchFestivalsFromApi(lang);
+
+        if (response == null || response.getResponse().getBody().getItems() == null) {
+            log.warn("Tour Api 조회 결과, 데이터가 비어있습니다. language: {}", lang);
+            return;
+        }
+
+        // 응답에서 아이템리스트 뽑아오기
+        List<TourApiEventItemDto> items = response.getResponse().getBody().getItems().getItem();
+
+        for (TourApiEventItemDto dto : items) {
+            // 공통 부분 정보 처리(upsert)
+            TourApiEvent event = eventRepository.findById(dto.getContentId()).orElseGet(
+                    () -> TourApiEvent.builder().contentId(dto.getContentId()).build());
+            updateEventEntity(event, dto);
+            eventRepository.save(event);
+
+            // 번역본
+            TourApiEventTranslation translation = translationRepository.findByEventAndLanguage(event, lang).orElseGet(
+                    () -> TourApiEventTranslation.builder().event(event).language(lang).build());
+
+            translation.setTitle(dto.getTitle());
+            translation.setAddress(dto.getAddr1() + (dto.getAddr2() != null ? " " + dto.getAddr2() : ""));
+            /// TODO: 추후 overview 채워야함
+            translationRepository.save(translation);
+        }
+        log.info("Successfully synced {} items for language: {}", items.size(), lang);
+
+    }
+
+    /**
+     * API 원본 데이터를 DTO로 반환 (테스트용)
+     */
+    public TourApiResponseDto<TourApiEventItemDto> getRawFestivals(TourLanguage lang) {
+        return fetchFestivalsFromApi(lang);
+    }
+
+    private TourApiResponseDto<TourApiEventItemDto> fetchFestivalsFromApi(TourLanguage lang) {
+        String url = lang.getServiceName() + "/searchFestival2";
+        String today = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(url)
+                        .queryParam("serviceKey", tourApiKey)
+                        .queryParam("MobileOS", "ETC")
+                        .queryParam("MobileApp", "BeyondToursSeoul")
+                        .queryParam("_type", "json")
+                        .queryParam("eventStartDate", today) // [필수 수정] 필수
+                        .queryParam("lDongRegnCd", "11")      // [수정] 서울 법정동
+//                        .queryParam("areaCode", "11")
+//                        .queryParam("numOfRows", 50)
+                        .build())
+                .retrieve().body(new ParameterizedTypeReference<TourApiResponseDto<TourApiEventItemDto>>() {
+                });
+    }
+
+    private void updateEventEntity(TourApiEvent event, TourApiEventItemDto dto) {
+        event.setContentTypeId(dto.getContentTypeId());
+        event.setFirstImage(dto.getFirstImage());
+        event.setFirstImage2(dto.getFirstImage2());
+        event.setMapX(dto.getMapX());
+        event.setMapY(dto.getMapY());
+        event.setTel(dto.getTel());
+        event.setZipCode(dto.getZipCode());
+        event.setEventStartDate(dto.getEventStartDate());
+        event.setEventEndDate(dto.getEventEndDate());
+        event.setAreaCode(dto.getAreaCode());
+        event.setSigunguCode(dto.getSigunguCode());
+        event.setModifiedTime(dto.getModifiedTime());
+        event.setLastSyncTime(LocalDateTime.now());
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,8 @@ google:
   translation:
     api:
       key: ${GOOGLE_TRANSLATION_API_KEY}
+
+visit:
+  seoul:
+    api:
+      key: ${VISIT_SEOUL_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,9 @@ google:
   translation:
     api:
       key: ${GOOGLE_TRANSLATION_API_KEY}
+
+# 공공데이터 포털 API 키
+public:
+  data:
+    api:
+      key: ${PUBLIC_DATA_API_KEY}


### PR DESCRIPTION
## 개요
> 문화행사 데이터 저장을 위한 기능 구현 및 엔티티 세팅

## 변경 사항
- TourController: 관광공사api 호출 테스트 api, DB저장 api 제작
- TourLanguage Enum 클래스 제작
- TourService 구현
- TourRepository 생성
- api 키 설정
- Tour 엔티티, Dto 구현
## 테스트
> 테스트한 내용을 작성해 주세요. (해당 없으면 삭제)
- [ ] 

## 관련 이슈
close #24 
