### PR TITLE
[FEAT] attraction_local_score 배치 계산

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/repository/AttractionLocalScoreRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/AttractionLocalScoreRepository.java
@@ -1,0 +1,12 @@
+package com.beyondtoursseoul.bts.repository;
+
+import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
+import com.beyondtoursseoul.bts.domain.AttractionLocalScoreId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface AttractionLocalScoreRepository extends JpaRepository<AttractionLocalScore, AttractionLocalScoreId> {
+
+    boolean existsByIdDate(LocalDate date);
+}

--- a/src/main/java/com/beyondtoursseoul/bts/runner/InitialDataLoader.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/InitialDataLoader.java
@@ -5,7 +5,8 @@ import com.beyondtoursseoul.bts.repository.DongLocalScoreRepository;
 import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
 import com.beyondtoursseoul.bts.service.AttractionMappingService;
 import com.beyondtoursseoul.bts.service.LocalResidentApiService;
-import com.beyondtoursseoul.bts.service.TourApiService;
+import com.beyondtoursseoul.bts.service.AttractionApiService;
+import com.beyondtoursseoul.bts.service.score.AttractionScoreService;
 import com.beyondtoursseoul.bts.service.score.LocalScoreCalculateService;
 import com.beyondtoursseoul.bts.service.score.PopulationCollectService;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,8 @@ public class InitialDataLoader implements ApplicationRunner {
     private final PopulationCollectService populationCollectService;
     private final LocalScoreCalculateService localScoreCalculateService;
     private final LocalResidentApiService localResidentApiService;
-    private final TourApiService tourApiService;
+    private final AttractionApiService tourApiService;
+    private final AttractionScoreService attractionScoreService;
 
     @Override
     public void run(ApplicationArguments args) {
@@ -80,6 +82,13 @@ public class InitialDataLoader implements ApplicationRunner {
             }
         } else {
             log.info("관광지 행정동 매핑이 이미 완료되어 있습니다.");
+        }
+
+        log.info("관광지 찐로컬 지수 계산 시작: {}", latestDate);
+        try {
+            attractionScoreService.calculateAndSave(latestDate);
+        } catch (Exception e) {
+            log.warn("관광지 찐로컬 지수 계산 실패 (건너뜀): {}", e.getMessage());
         }
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
+++ b/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
@@ -2,6 +2,7 @@ package com.beyondtoursseoul.bts.scheduler;
 
 import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
 import com.beyondtoursseoul.bts.service.LocalResidentApiService;
+import com.beyondtoursseoul.bts.service.score.AttractionScoreService;
 import com.beyondtoursseoul.bts.service.score.LocalScoreCalculateService;
 import com.beyondtoursseoul.bts.service.score.PopulationCollectService;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ public class DailyScoreScheduler {
     private final LocalResidentApiService localResidentApiService;
     private final PopulationCollectService populationCollectService;
     private final LocalScoreCalculateService localScoreCalculateService;
+    private final AttractionScoreService attractionScoreService;
     private final DongPopulationRawRepository rawRepository;
 
     @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
@@ -34,6 +36,7 @@ public class DailyScoreScheduler {
 
             populationCollectService.collect(targetDate);
             localScoreCalculateService.calculateAndSave(targetDate);
+            attractionScoreService.calculateAndSave(targetDate);
             log.info("[DailyScoreScheduler] 완료: {}", targetDate);
         } catch (Exception e) {
             log.error("[DailyScoreScheduler] 실패 — {}", e.getMessage(), e);

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionApiService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionApiService.java
@@ -14,13 +14,14 @@ import org.springframework.web.client.RestClient;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
-public class TourApiService {
+public class AttractionApiService {
 
     private static final String BASE_URL = "https://apis.data.go.kr/B551011/KorService2/areaBasedList2";
-    private static final String SEOUL_RIEGN_CD = "11";
+    private static final String SEOUL_REGION_CD = "11";
     private static final String SOURCE = "TOUR_API";
     private static final int PAGE_SIZE = 1000;
 
@@ -31,7 +32,7 @@ public class TourApiService {
     @Value("${PUBLIC_DATA_API_KEY}")
     private String apiKey;
 
-    public TourApiService() {
+    public AttractionApiService() {
         this.restClient = RestClient.create();
     }
 
@@ -49,7 +50,7 @@ public class TourApiService {
             if (response == null
                     || response.getResponse() == null
                     || response.getResponse().getBody() == null) {
-                log.warn("[TourAPI] 응답 없음 — pageNo: {}", pageNo);
+                log.warn("[AttractionApi] 응답 없음 — pageNo: {}", pageNo);
                 break;
             }
 
@@ -57,12 +58,12 @@ public class TourApiService {
             totalCount = body.getTotalCount();
 
             if (body.getItems() == null || body.getItems().getItem() == null) {
-                log.warn("[TourAPI] 항목 없음 — pageNo: {}", pageNo);
+                log.warn("[AttractionApi] 항목 없음 — pageNo: {}", pageNo);
                 break;
             }
 
             List<Item> items = body.getItems().getItem();
-            log.info("[TourAPI] pageNo={}, totalCount={}, 수신={}건", pageNo, totalCount, items.size());
+            log.info("[AttractionApi] pageNo={}, totalCount={}, 수신={}건", pageNo, totalCount, items.size());
 
             for (Item item : items) {
                 toAttraction(item).ifPresent(result::add);
@@ -71,25 +72,25 @@ public class TourApiService {
             pageNo++;
         }
 
-        log.info("[TourAPI] 서울 관광지 수집 완료: {}건", result.size());
+        log.info("[AttractionApi] 서울 관광지 수집 완료: {}건", result.size());
         return result;
     }
 
-    private java.util.Optional<com.beyondtoursseoul.bts.domain.Attraction> toAttraction(Item item) {
+    private Optional<com.beyondtoursseoul.bts.domain.Attraction> toAttraction(Item item) {
         if (item.getMapX() == null || item.getMapX().isBlank()
                 || item.getMapY() == null || item.getMapY().isBlank()) {
-            return java.util.Optional.empty();
+            return Optional.empty();
         }
 
         try {
             double lng = Double.parseDouble(item.getMapX());
             double lat = Double.parseDouble(item.getMapY());
 
-            if (lng == 0.0 || lat == 0.0) return java.util.Optional.empty();
+            if (lng == 0.0 || lat == 0.0) return Optional.empty();
 
             Point geom = GF.createPoint(new Coordinate(lng, lat));
 
-            return java.util.Optional.of(
+            return Optional.of(
                     com.beyondtoursseoul.bts.domain.Attraction.builder()
                             .externalId(item.getContentId())
                             .name(item.getTitle())
@@ -101,8 +102,8 @@ public class TourApiService {
                             .build()
             );
         } catch (NumberFormatException e) {
-            log.warn("[TourAPI] 좌표 파싱 실패 contentId={}: {}", item.getContentId(), e.getMessage());
-            return java.util.Optional.empty();
+            log.warn("[AttractionApi] 좌표 파싱 실패 contentId={}: {}", item.getContentId(), e.getMessage());
+            return Optional.empty();
         }
     }
 
@@ -115,6 +116,6 @@ public class TourApiService {
                 + "&MobileApp=BTS"
                 + "&_type=json"
                 + "&arrange=A"
-                + "&lDongRegnCd=" + SEOUL_RIEGN_CD;
+                + "&lDongRegnCd=" + SEOUL_REGION_CD;
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/service/score/AttractionScoreService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/score/AttractionScoreService.java
@@ -1,0 +1,64 @@
+package com.beyondtoursseoul.bts.service.score;
+
+import com.beyondtoursseoul.bts.repository.AttractionLocalScoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AttractionScoreService {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final AttractionLocalScoreRepository repository;
+
+    private static final List<String> ALL_TIME_SLOTS = Arrays.stream(TimeSlot.values())
+            .map(TimeSlot::getCode)
+            .toList();
+
+    public void calculateAndSave(LocalDate date) {
+        if (repository.existsByIdDate(date)) {
+            log.info("[AttractionScore] {} 이미 계산됨 — 스킵", date);
+            return;
+        }
+
+        int total = 0;
+        for (String timeSlot : ALL_TIME_SLOTS) {
+            int count = insertForTimeSlot(date, timeSlot);
+            total += count;
+            log.info("[AttractionScore] {} {} — {}건 저장", date, timeSlot, count);
+        }
+
+        log.info("[AttractionScore] 완료: {} 총 {}건", date, total);
+    }
+
+    private int insertForTimeSlot(LocalDate date, String timeSlot) {
+        return jdbcTemplate.update("""
+                INSERT INTO attraction_local_score (attraction_id, date, time_slot, score)
+                SELECT a.id, ?, ?, s.score
+                FROM attraction a
+                JOIN dong_local_score s ON s.dong_code = a.dong_code
+                WHERE s.date = ? AND s.time_slot = ?
+                  AND a.dong_code IS NOT NULL
+                ON CONFLICT (attraction_id, date, time_slot) DO UPDATE SET score = EXCLUDED.score
+                """, date, timeSlot, date, timeSlot);
+    }
+
+    // Approach C: contentTypeId 기준 대표 시간대
+    public static TimeSlot primaryTimeSlot(String contentTypeId) {
+        if (contentTypeId == null) return TimeSlot.AFTERNOON;
+        return switch (contentTypeId) {
+            case "39" -> TimeSlot.EVENING;    // 음식점
+            case "15" -> TimeSlot.EVENING;    // 행사/공연/축제
+            case "28" -> TimeSlot.MORNING;    // 레포츠
+            case "32" -> TimeSlot.MORNING;    // 숙박
+            default   -> TimeSlot.AFTERNOON;  // 관광지(12), 문화시설(14), 쇼핑(38) 등
+        };
+    }
+}

--- a/src/test/java/com/beyondtoursseoul/bts/scheduler/DailyScoreSchedulerTest.java
+++ b/src/test/java/com/beyondtoursseoul/bts/scheduler/DailyScoreSchedulerTest.java
@@ -2,6 +2,7 @@ package com.beyondtoursseoul.bts.scheduler;
 
 import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
 import com.beyondtoursseoul.bts.service.LocalResidentApiService;
+import com.beyondtoursseoul.bts.service.score.AttractionScoreService;
 import com.beyondtoursseoul.bts.service.score.LocalScoreCalculateService;
 import com.beyondtoursseoul.bts.service.score.PopulationCollectService;
 import org.junit.jupiter.api.Test;
@@ -22,25 +23,27 @@ class DailyScoreSchedulerTest {
     @Mock LocalResidentApiService localResidentApiService;
     @Mock PopulationCollectService populationCollectService;
     @Mock LocalScoreCalculateService localScoreCalculateService;
+    @Mock AttractionScoreService attractionScoreService;
     @Mock DongPopulationRawRepository rawRepository;
 
     @InjectMocks DailyScoreScheduler scheduler;
 
     @Test
-    void 신규_날짜면_수집과_계산이_순서대로_실행된다() {
+    void 신규_날짜면_수집_계산_관광지점수_순서대로_실행된다() {
         LocalDate targetDate = LocalDate.of(2026, 4, 28);
         when(localResidentApiService.findLatestAvailableDate()).thenReturn(targetDate);
         when(rawRepository.existsByDate(targetDate)).thenReturn(false);
 
         scheduler.run();
 
-        InOrder order = inOrder(populationCollectService, localScoreCalculateService);
+        InOrder order = inOrder(populationCollectService, localScoreCalculateService, attractionScoreService);
         order.verify(populationCollectService).collect(targetDate);
         order.verify(localScoreCalculateService).calculateAndSave(targetDate);
+        order.verify(attractionScoreService).calculateAndSave(targetDate);
     }
 
     @Test
-    void 이미_수집된_날짜면_수집과_계산을_건너뛴다() {
+    void 이미_수집된_날짜면_모든_단계를_건너뛴다() {
         LocalDate targetDate = LocalDate.of(2026, 4, 28);
         when(localResidentApiService.findLatestAvailableDate()).thenReturn(targetDate);
         when(rawRepository.existsByDate(targetDate)).thenReturn(true);
@@ -49,6 +52,7 @@ class DailyScoreSchedulerTest {
 
         verify(populationCollectService, never()).collect(any());
         verify(localScoreCalculateService, never()).calculateAndSave(any());
+        verify(attractionScoreService, never()).calculateAndSave(any());
     }
 
     @Test
@@ -60,10 +64,11 @@ class DailyScoreSchedulerTest {
 
         verify(populationCollectService, never()).collect(any());
         verify(localScoreCalculateService, never()).calculateAndSave(any());
+        verify(attractionScoreService, never()).calculateAndSave(any());
     }
 
     @Test
-    void 수집_실패시_계산을_실행하지_않고_앱이_죽지_않는다() {
+    void 수집_실패시_이후_단계를_실행하지_않고_앱이_죽지_않는다() {
         LocalDate targetDate = LocalDate.of(2026, 4, 28);
         when(localResidentApiService.findLatestAvailableDate()).thenReturn(targetDate);
         when(rawRepository.existsByDate(targetDate)).thenReturn(false);
@@ -72,5 +77,6 @@ class DailyScoreSchedulerTest {
         assertDoesNotThrow(() -> scheduler.run());
 
         verify(localScoreCalculateService, never()).calculateAndSave(any());
+        verify(attractionScoreService, never()).calculateAndSave(any());
     }
 }

--- a/src/test/java/com/beyondtoursseoul/bts/service/AttractionScoreServiceTest.java
+++ b/src/test/java/com/beyondtoursseoul/bts/service/AttractionScoreServiceTest.java
@@ -1,0 +1,60 @@
+package com.beyondtoursseoul.bts.service;
+
+import com.beyondtoursseoul.bts.repository.AttractionLocalScoreRepository;
+import com.beyondtoursseoul.bts.service.score.AttractionScoreService;
+import com.beyondtoursseoul.bts.service.score.TimeSlot;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AttractionScoreServiceTest {
+
+    @Mock JdbcTemplate jdbcTemplate;
+    @Mock AttractionLocalScoreRepository repository;
+
+    @InjectMocks AttractionScoreService service;
+
+    @Test
+    void 신규_날짜면_전체_시간대_5회_INSERT한다() {
+        LocalDate date = LocalDate.of(2026, 4, 28);
+        when(repository.existsByIdDate(date)).thenReturn(false);
+        when(jdbcTemplate.update(any(String.class), any(), any(), any(), any())).thenReturn(100);
+
+        service.calculateAndSave(date);
+
+        verify(jdbcTemplate, times(TimeSlot.values().length)).update(any(String.class), any(), any(), any(), any());
+    }
+
+    @Test
+    void 이미_계산된_날짜면_INSERT하지_않는다() {
+        LocalDate date = LocalDate.of(2026, 4, 28);
+        when(repository.existsByIdDate(date)).thenReturn(true);
+
+        service.calculateAndSave(date);
+
+        verify(jdbcTemplate, never()).update(any(String.class), any(), any(), any(), any());
+    }
+
+    @Test
+    void 카테고리별_대표_시간대_매핑이_올바르다() {
+        assertThat(AttractionScoreService.primaryTimeSlot("39")).isEqualTo(TimeSlot.EVENING);   // 음식점
+        assertThat(AttractionScoreService.primaryTimeSlot("15")).isEqualTo(TimeSlot.EVENING);   // 행사/공연
+        assertThat(AttractionScoreService.primaryTimeSlot("28")).isEqualTo(TimeSlot.MORNING);   // 레포츠
+        assertThat(AttractionScoreService.primaryTimeSlot("32")).isEqualTo(TimeSlot.MORNING);   // 숙박
+        assertThat(AttractionScoreService.primaryTimeSlot("12")).isEqualTo(TimeSlot.AFTERNOON); // 관광지
+        assertThat(AttractionScoreService.primaryTimeSlot("14")).isEqualTo(TimeSlot.AFTERNOON); // 문화시설
+        assertThat(AttractionScoreService.primaryTimeSlot("38")).isEqualTo(TimeSlot.AFTERNOON); // 쇼핑
+        assertThat(AttractionScoreService.primaryTimeSlot(null)).isEqualTo(TimeSlot.AFTERNOON); // null
+    }
+}

--- a/src/test/java/com/beyondtoursseoul/bts/service/TourApiServiceTest.java
+++ b/src/test/java/com/beyondtoursseoul/bts/service/TourApiServiceTest.java
@@ -1,5 +1,6 @@
 package com.beyondtoursseoul.bts.service;
 
+import com.beyondtoursseoul.bts.service.AttractionApiService;
 import com.beyondtoursseoul.bts.domain.Attraction;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TourApiServiceTest {
 
     @Autowired
-    private TourApiService tourApiService;
+    private AttractionApiService tourApiService;
 
     @Test
     void 서울_관광지_수집_성공() {


### PR DESCRIPTION
## 개요

> attraction 테이블에 매핑된 dong_code를 기준으로, 매일 배치로
> attraction_local_score 테이블에 관광지별 찐로컬 지수를 계산해 저장한다.

## 변경 사항

- AttractionLocalScoreRepository 생성 (멱등성 체크용 existsByIdDate)
- AttractionScoreService 생성
  - calculateAndSave(LocalDate): 5개 time_slot × 전체 attraction 배치 INSERT (JdbcTemplate)
  - primaryTimeSlot(String contentTypeId): contentTypeId → 대표 TimeSlot 매핑 (Approach C)
- DailyScoreScheduler에 마지막 단계로 attractionScoreService.calculateAndSave() 추가
- 단위 테스트 작성

## 관련 이슈
close #50
