### PR TITLE
[FIX] attraction_local_score 미적재 — dong_local_score 날짜 미스매치

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/repository/DongLocalScoreRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/DongLocalScoreRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DongLocalScoreRepository extends JpaRepository<DongLocalScore, Long> {
 
@@ -13,4 +14,6 @@ public interface DongLocalScoreRepository extends JpaRepository<DongLocalScore, 
     List<DongLocalScore> findByDate(LocalDate date);
 
     void deleteByDateAndTimeSlot(LocalDate date, String timeSlot);
+
+    Optional<DongLocalScore> findTopByOrderByDateDesc();
 }

--- a/src/main/java/com/beyondtoursseoul/bts/runner/InitialDataLoader.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/InitialDataLoader.java
@@ -84,11 +84,17 @@ public class InitialDataLoader implements ApplicationRunner {
             log.info("관광지 행정동 매핑이 이미 완료되어 있습니다.");
         }
 
-        log.info("관광지 찐로컬 지수 계산 시작: {}", latestDate);
-        try {
-            attractionScoreService.calculateAndSave(latestDate);
-        } catch (Exception e) {
-            log.warn("관광지 찐로컬 지수 계산 실패 (건너뜀): {}", e.getMessage());
-        }
+        // dong_local_score에 실제로 존재하는 최신 날짜 기준으로 계산 (latestDate와 불일치 방지)
+        scoreRepository.findTopByOrderByDateDesc().ifPresentOrElse(
+                latestScore -> {
+                    log.info("관광지 찐로컬 지수 계산 시작: {}", latestScore.getDate());
+                    try {
+                        attractionScoreService.calculateAndSave(latestScore.getDate());
+                    } catch (Exception e) {
+                        log.warn("관광지 찐로컬 지수 계산 실패 (건너뜀): {}", e.getMessage());
+                    }
+                },
+                () -> log.warn("dong_local_score 데이터가 없어 관광지 지수 계산을 건너뜁니다.")
+        );
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/service/score/AttractionScoreService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/score/AttractionScoreService.java
@@ -7,8 +7,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -18,10 +16,6 @@ public class AttractionScoreService {
     private final JdbcTemplate jdbcTemplate;
     private final AttractionLocalScoreRepository repository;
 
-    private static final List<String> ALL_TIME_SLOTS = Arrays.stream(TimeSlot.values())
-            .map(TimeSlot::getCode)
-            .toList();
-
     public void calculateAndSave(LocalDate date) {
         if (repository.existsByIdDate(date)) {
             log.info("[AttractionScore] {} 이미 계산됨 — 스킵", date);
@@ -29,25 +23,25 @@ public class AttractionScoreService {
         }
 
         int total = 0;
-        for (String timeSlot : ALL_TIME_SLOTS) {
+        for (TimeSlot timeSlot : TimeSlot.values()) {
             int count = insertForTimeSlot(date, timeSlot);
             total += count;
-            log.info("[AttractionScore] {} {} — {}건 저장", date, timeSlot, count);
+            log.info("[AttractionScore] {} {} — {}건 저장", date, timeSlot.getCode(), count);
         }
 
         log.info("[AttractionScore] 완료: {} 총 {}건", date, total);
     }
 
-    private int insertForTimeSlot(LocalDate date, String timeSlot) {
+    private int insertForTimeSlot(LocalDate date, TimeSlot timeSlot) {
         return jdbcTemplate.update("""
-                INSERT INTO attraction_local_score (attraction_id, date, time_slot, score)
-                SELECT a.id, ?, ?, s.score
+                INSERT INTO attraction_local_score (attraction_id, date, time_slot, hour, score)
+                SELECT a.id, ?, ?, ?, s.score
                 FROM attraction a
                 JOIN dong_local_score s ON s.dong_code = a.dong_code
                 WHERE s.date = ? AND s.time_slot = ?
                   AND a.dong_code IS NOT NULL
                 ON CONFLICT (attraction_id, date, time_slot) DO UPDATE SET score = EXCLUDED.score
-                """, date, timeSlot, date, timeSlot);
+                """, date, timeSlot.getCode(), timeSlot.getStartHour(), date, timeSlot.getCode());
     }
 
     // Approach C: contentTypeId 기준 대표 시간대

--- a/src/test/java/com/beyondtoursseoul/bts/service/AttractionScoreServiceTest.java
+++ b/src/test/java/com/beyondtoursseoul/bts/service/AttractionScoreServiceTest.java
@@ -28,11 +28,11 @@ class AttractionScoreServiceTest {
     void 신규_날짜면_전체_시간대_5회_INSERT한다() {
         LocalDate date = LocalDate.of(2026, 4, 28);
         when(repository.existsByIdDate(date)).thenReturn(false);
-        when(jdbcTemplate.update(any(String.class), any(), any(), any(), any())).thenReturn(100);
+        when(jdbcTemplate.update(any(String.class), any(), any(), any(), any(), any())).thenReturn(100);
 
         service.calculateAndSave(date);
 
-        verify(jdbcTemplate, times(TimeSlot.values().length)).update(any(String.class), any(), any(), any(), any());
+        verify(jdbcTemplate, times(TimeSlot.values().length)).update(any(String.class), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -42,7 +42,7 @@ class AttractionScoreServiceTest {
 
         service.calculateAndSave(date);
 
-        verify(jdbcTemplate, never()).update(any(String.class), any(), any(), any(), any());
+        verify(jdbcTemplate, never()).update(any(String.class), any(), any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 개요

> InitialDataLoader에서 attractionScoreService.calculateAndSave(latestDate)를
> 호출할 때 latestDate는 생활인구 API 기준 날짜를 사용한다.
> 
> 그러나 dong_local_score에 저장된 날짜가 latestDate와 다를 경우
> AttractionScoreService의 JOIN 조건(s.date = ?)이 매칭되지 않아
> attraction_local_score에 0건이 INSERT된다.

## 변경 사항

- DongLocalScoreRepository에 findTopByOrderByDateDesc() 추가
- InitialDataLoader에서 attractionScoreService 호출 시 latestDate 대신 dong_local_score의 실제 최신 날짜 사용
- dong_local_score가 비어있을 경우 경고 로그만 남기고 스킵 처리


## 관련 이슈
close #55