### PR TITLE
[FEAT] 관광지 목록/상세 조회 API 구현

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/config/JacksonConfig.java
+++ b/src/main/java/com/beyondtoursseoul/bts/config/JacksonConfig.java
@@ -1,0 +1,30 @@
+package com.beyondtoursseoul.bts.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
+import com.fasterxml.jackson.databind.type.LogicalType;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+
+        // TourAPI가 빈 문자열("")로 오는 필드를 null로 처리
+        mapper.coercionConfigFor(LogicalType.POJO)
+                .setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
+        mapper.coercionConfigFor(LogicalType.Collection)
+                .setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
+
+        return mapper;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
@@ -1,0 +1,32 @@
+package com.beyondtoursseoul.bts.controller;
+
+import com.beyondtoursseoul.bts.dto.attraction.AttractionDetailResponse;
+import com.beyondtoursseoul.bts.dto.attraction.AttractionSummaryResponse;
+import com.beyondtoursseoul.bts.service.AttractionQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/attractions")
+@RequiredArgsConstructor
+public class AttractionController {
+
+    private final AttractionQueryService attractionQueryService;
+
+    @GetMapping
+    public ResponseEntity<List<AttractionSummaryResponse>> getList(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(defaultValue = "afternoon") String timeSlot) {
+        return ResponseEntity.ok(attractionQueryService.getList(date, timeSlot));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AttractionDetailResponse> getDetail(@PathVariable Long id) {
+        return ResponseEntity.ok(attractionQueryService.getDetail(id));
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/Attraction.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/Attraction.java
@@ -42,9 +42,34 @@ public class Attraction {
     @Column(name = "created_at")
     private OffsetDateTime createdAt;
 
+    private String thumbnail;
+
+    @Column(length = 10)
+    private String cat1;
+
+    @Column(length = 10)
+    private String cat2;
+
+    @Column(length = 10)
+    private String cat3;
+
+    @Column(columnDefinition = "TEXT")
+    private String tel;
+
+    @Column(columnDefinition = "TEXT")
+    private String overview;
+
+    @Column(name = "operating_hours", columnDefinition = "TEXT")
+    private String operatingHours;
+
+    @Column(name = "detail_fetched", nullable = false)
+    private boolean detailFetched = false;
+
     @Builder
     public Attraction(String externalId, String name, String category, String address,
-                      Point geom, String dongCode, String source, OffsetDateTime createdAt) {
+                      Point geom, String dongCode, String source, OffsetDateTime createdAt,
+                      String thumbnail, String cat1, String cat2, String cat3,
+                      String tel, String overview, String operatingHours) {
         this.externalId = externalId;
         this.name = name;
         this.category = category;
@@ -53,9 +78,23 @@ public class Attraction {
         this.dongCode = dongCode;
         this.source = source;
         this.createdAt = createdAt;
+        this.thumbnail = thumbnail;
+        this.cat1 = cat1;
+        this.cat2 = cat2;
+        this.cat3 = cat3;
+        this.tel = tel;
+        this.overview = overview;
+        this.operatingHours = operatingHours;
     }
 
     public void updateDongCode(String dongCode) {
         this.dongCode = dongCode;
+    }
+
+    public void updateDetail(String overview, String operatingHours, String tel) {
+        this.overview = overview;
+        this.operatingHours = operatingHours;
+        if (this.tel == null && tel != null) this.tel = tel;
+        this.detailFetched = true;
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/domain/TourCategory.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/TourCategory.java
@@ -1,0 +1,31 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tour_category")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TourCategory {
+
+    @Id
+    @Column(length = 10)
+    private String code;
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer level;
+
+    @Builder
+    public TourCategory(String code, String name, Integer level) {
+        this.code = code;
+        this.name = name;
+        this.level = level;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/CategoryCodeResponseDto.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/CategoryCodeResponseDto.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class TourApiResponseDto {
+public class CategoryCodeResponseDto {
 
     @JsonProperty("response")
     private Response response;
@@ -19,7 +19,6 @@ public class TourApiResponseDto {
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Response {
-
         @JsonProperty("body")
         private Body body;
     }
@@ -28,25 +27,14 @@ public class TourApiResponseDto {
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Body {
-
         @JsonProperty("items")
         private Items items;
-
-        @JsonProperty("totalCount")
-        private int totalCount;
-
-        @JsonProperty("numOfRows")
-        private int numOfRows;
-
-        @JsonProperty("pageNo")
-        private int pageNo;
     }
 
     @Getter
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Items {
-
         @JsonProperty("item")
         private List<Item> item;
     }
@@ -55,38 +43,10 @@ public class TourApiResponseDto {
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Item {
+        @JsonProperty("code")
+        private String code;
 
-        @JsonProperty("contentid")
-        private String contentId;
-
-        @JsonProperty("title")
-        private String title;
-
-        @JsonProperty("contenttypeid")
-        private String contentTypeId;
-
-        @JsonProperty("addr1")
-        private String addr1;
-
-        @JsonProperty("mapx")
-        private String mapX;
-
-        @JsonProperty("mapy")
-        private String mapY;
-
-        @JsonProperty("firstimage")
-        private String firstImage;
-
-        @JsonProperty("lclsSystm1")
-        private String cat1;
-
-        @JsonProperty("lclsSystm2")
-        private String cat2;
-
-        @JsonProperty("lclsSystm3")
-        private String cat3;
-
-        @JsonProperty("tel")
-        private String tel;
+        @JsonProperty("name")
+        private String name;
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/dto/DetailCommonResponseDto.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/DetailCommonResponseDto.java
@@ -1,0 +1,52 @@
+package com.beyondtoursseoul.bts.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DetailCommonResponseDto {
+
+    @JsonProperty("response")
+    private Response response;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Response {
+        @JsonProperty("body")
+        private Body body;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Body {
+        @JsonProperty("items")
+        private Items items;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Items {
+        @JsonProperty("item")
+        private List<Item> item;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Item {
+        @JsonProperty("overview")
+        private String overview;
+
+        @JsonProperty("tel")
+        private String tel;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/DetailInfoResponseDto.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/DetailInfoResponseDto.java
@@ -1,0 +1,70 @@
+package com.beyondtoursseoul.bts.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DetailInfoResponseDto {
+
+    @JsonProperty("response")
+    private Response response;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Response {
+        @JsonProperty("body")
+        private Body body;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Body {
+        @JsonProperty("items")
+        private Items items;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Items {
+        @JsonProperty("item")
+        private List<Item> item;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Item {
+        @JsonProperty("usetime")
+        private String usetime;
+
+        @JsonProperty("usetimeculture")
+        private String usetimeculture;
+
+        @JsonProperty("opentimefood")
+        private String opentimefood;
+
+        @JsonProperty("opentime")
+        private String opentime;
+
+        @JsonProperty("useseason")
+        private String useseason;
+
+        public String resolveOperatingHours() {
+            if (usetime != null && !usetime.isBlank()) return usetime;
+            if (usetimeculture != null && !usetimeculture.isBlank()) return usetimeculture;
+            if (opentimefood != null && !opentimefood.isBlank()) return opentimefood;
+            if (opentime != null && !opentime.isBlank()) return opentime;
+            if (useseason != null && !useseason.isBlank()) return useseason;
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionDetailResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionDetailResponse.java
@@ -1,0 +1,44 @@
+package com.beyondtoursseoul.bts.dto.attraction;
+
+import com.beyondtoursseoul.bts.domain.Attraction;
+import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Getter
+public class AttractionDetailResponse {
+
+    private final Long id;
+    private final String name;
+    private final String thumbnail;
+    private final String cat1Name;
+    private final String cat2Name;
+    private final String cat3Name;
+    private final String address;
+    private final double lng;
+    private final double lat;
+    private final String tel;
+    private final String overview;
+    private final String operatingHours;
+    private final Map<String, BigDecimal> scores;
+
+    public AttractionDetailResponse(Attraction attraction,
+                                    String cat1Name, String cat2Name, String cat3Name,
+                                    Map<String, BigDecimal> scores) {
+        this.id = attraction.getId();
+        this.name = attraction.getName();
+        this.thumbnail = attraction.getThumbnail();
+        this.cat1Name = cat1Name;
+        this.cat2Name = cat2Name;
+        this.cat3Name = cat3Name;
+        this.address = attraction.getAddress();
+        this.lng = attraction.getGeom().getX();
+        this.lat = attraction.getGeom().getY();
+        this.tel = attraction.getTel();
+        this.overview = attraction.getOverview();
+        this.operatingHours = attraction.getOperatingHours();
+        this.scores = scores;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionSummaryResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionSummaryResponse.java
@@ -1,0 +1,36 @@
+package com.beyondtoursseoul.bts.dto.attraction;
+
+import com.beyondtoursseoul.bts.domain.Attraction;
+import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class AttractionSummaryResponse {
+
+    private final Long id;
+    private final String name;
+    private final String thumbnail;
+    private final String cat1Name;
+    private final String cat2Name;
+    private final String cat3Name;
+    private final String address;
+    private final double lng;
+    private final double lat;
+    private final BigDecimal score;
+
+    public AttractionSummaryResponse(Attraction attraction, AttractionLocalScore score,
+                                     String cat1Name, String cat2Name, String cat3Name) {
+        this.id = attraction.getId();
+        this.name = attraction.getName();
+        this.thumbnail = attraction.getThumbnail();
+        this.cat1Name = cat1Name;
+        this.cat2Name = cat2Name;
+        this.cat3Name = cat3Name;
+        this.address = attraction.getAddress();
+        this.lng = attraction.getGeom().getX();
+        this.lat = attraction.getGeom().getY();
+        this.score = score != null ? score.getScore() : null;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/repository/AttractionLocalScoreRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/AttractionLocalScoreRepository.java
@@ -3,10 +3,20 @@ package com.beyondtoursseoul.bts.repository;
 import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
 import com.beyondtoursseoul.bts.domain.AttractionLocalScoreId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 public interface AttractionLocalScoreRepository extends JpaRepository<AttractionLocalScore, AttractionLocalScoreId> {
 
     boolean existsByIdDate(LocalDate date);
+
+    @Query("SELECT MAX(a.id.date) FROM AttractionLocalScore a")
+    Optional<LocalDate> findLatestDate();
+
+    List<AttractionLocalScore> findByIdAttractionId(Long attractionId);
+
+    List<AttractionLocalScore> findByIdDateAndIdTimeSlot(LocalDate date, String timeSlot);
 }

--- a/src/main/java/com/beyondtoursseoul/bts/repository/TourCategoryRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/TourCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.beyondtoursseoul.bts.repository;
+
+import com.beyondtoursseoul.bts.domain.TourCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TourCategoryRepository extends JpaRepository<TourCategory, String> {
+}

--- a/src/main/java/com/beyondtoursseoul/bts/runner/CategoryInitRunner.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/CategoryInitRunner.java
@@ -1,0 +1,100 @@
+package com.beyondtoursseoul.bts.runner;
+
+import com.beyondtoursseoul.bts.domain.TourCategory;
+import com.beyondtoursseoul.bts.dto.CategoryCodeResponseDto;
+import com.beyondtoursseoul.bts.repository.TourCategoryRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@Order(1)
+public class CategoryInitRunner implements ApplicationRunner {
+
+    private static final String BASE_URL = "https://apis.data.go.kr/B551011/KorService2/lclsSystmCode2";
+
+    private final TourCategoryRepository repository;
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${PUBLIC_DATA_API_KEY}")
+    private String apiKey;
+
+    public CategoryInitRunner(TourCategoryRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.restClient = RestClient.create();
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (repository.count() > 0) {
+            log.info("[CategoryInit] 카테고리 데이터 이미 존재 — 스킵");
+            return;
+        }
+
+        log.info("[CategoryInit] 카테고리 코드 수집 시작");
+        List<TourCategory> all = new ArrayList<>();
+
+        List<CategoryCodeResponseDto.Item> lv1List = fetchCategories(null, null);
+        log.info("[CategoryInit] lv1 {}건 수신", lv1List.size());
+        for (CategoryCodeResponseDto.Item lv1 : lv1List) {
+            if (lv1.getCode() == null) { log.warn("[CategoryInit] lv1 code null, name={}", lv1.getName()); continue; }
+            all.add(TourCategory.builder().code(lv1.getCode()).name(lv1.getName()).level(1).build());
+
+            List<CategoryCodeResponseDto.Item> lv2List = fetchCategories(lv1.getCode(), null);
+            log.info("[CategoryInit] lv2 of {} — {}건 수신", lv1.getCode(), lv2List.size());
+            for (CategoryCodeResponseDto.Item lv2 : lv2List) {
+                if (lv2.getCode() == null) { log.warn("[CategoryInit] lv2 code null, name={}", lv2.getName()); continue; }
+                all.add(TourCategory.builder().code(lv2.getCode()).name(lv2.getName()).level(2).build());
+
+                List<CategoryCodeResponseDto.Item> lv3List = fetchCategories(lv1.getCode(), lv2.getCode());
+                log.info("[CategoryInit] lv3 of {}/{} — {}건 수신", lv1.getCode(), lv2.getCode(), lv3List.size());
+                for (CategoryCodeResponseDto.Item lv3 : lv3List) {
+                    if (lv3.getCode() == null) { log.warn("[CategoryInit] lv3 code null, name={}", lv3.getName()); continue; }
+                    all.add(TourCategory.builder().code(lv3.getCode()).name(lv3.getName()).level(3).build());
+                }
+            }
+        }
+
+        repository.saveAll(all);
+        long lv1Count = all.stream().filter(c -> c.getLevel() == 1).count();
+        long lv2Count = all.stream().filter(c -> c.getLevel() == 2).count();
+        long lv3Count = all.stream().filter(c -> c.getLevel() == 3).count();
+        log.info("[CategoryInit] 저장 완료 — lv1:{}, lv2:{}, lv3:{}, 합계:{}", lv1Count, lv2Count, lv3Count, all.size());
+    }
+
+    private List<CategoryCodeResponseDto.Item> fetchCategories(String cat1, String cat2) {
+        try {
+            String url = BASE_URL
+                    + "?serviceKey=" + apiKey
+                    + "&MobileOS=ETC&MobileApp=BTS&_type=json"
+                    + (cat1 != null ? "&lclsSystm1=" + cat1 : "")
+                    + (cat2 != null ? "&lclsSystm2=" + cat2 : "");
+
+            String json = restClient.get().uri(url).retrieve().body(String.class);
+            CategoryCodeResponseDto response = objectMapper.readValue(json, CategoryCodeResponseDto.class);
+
+            if (response == null
+                    || response.getResponse() == null
+                    || response.getResponse().getBody() == null
+                    || response.getResponse().getBody().getItems() == null
+                    || response.getResponse().getBody().getItems().getItem() == null) {
+                return List.of();
+            }
+            return response.getResponse().getBody().getItems().getItem();
+        } catch (Exception e) {
+            log.warn("[CategoryInit] 카테고리 조회 실패 cat1={} cat2={}: {}", cat1, cat2, e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionApiService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionApiService.java
@@ -1,7 +1,11 @@
 package com.beyondtoursseoul.bts.service;
 
+import com.beyondtoursseoul.bts.domain.Attraction;
+import com.beyondtoursseoul.bts.dto.DetailCommonResponseDto;
+import com.beyondtoursseoul.bts.dto.DetailInfoResponseDto;
 import com.beyondtoursseoul.bts.dto.TourApiResponseDto;
 import com.beyondtoursseoul.bts.dto.TourApiResponseDto.Item;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -21,6 +25,8 @@ import java.util.Optional;
 public class AttractionApiService {
 
     private static final String BASE_URL = "https://apis.data.go.kr/B551011/KorService2/areaBasedList2";
+    private static final String DETAIL_COMMON_URL = "https://apis.data.go.kr/B551011/KorService2/detailCommon2";
+    private static final String DETAIL_INTRO_URL = "https://apis.data.go.kr/B551011/KorService2/detailIntro2";
     private static final String SEOUL_REGION_CD = "11";
     private static final String SOURCE = "TOUR_API";
     private static final int PAGE_SIZE = 1000;
@@ -28,45 +34,54 @@ public class AttractionApiService {
     private static final GeometryFactory GF = new GeometryFactory(new PrecisionModel(), 4326);
 
     private final RestClient restClient;
+    private final ObjectMapper objectMapper;
 
     @Value("${PUBLIC_DATA_API_KEY}")
     private String apiKey;
 
-    public AttractionApiService() {
+    public AttractionApiService(ObjectMapper objectMapper) {
         this.restClient = RestClient.create();
+        this.objectMapper = objectMapper;
     }
 
-    public List<com.beyondtoursseoul.bts.domain.Attraction> fetchSeoulAttractions() {
-        List<com.beyondtoursseoul.bts.domain.Attraction> result = new ArrayList<>();
+    public List<Attraction> fetchSeoulAttractions() {
+        List<Attraction> result = new ArrayList<>();
         int pageNo = 1;
         int totalCount = Integer.MAX_VALUE;
 
         while ((long) (pageNo - 1) * PAGE_SIZE < totalCount) {
-            TourApiResponseDto response = restClient.get()
-                    .uri(buildUrl(pageNo))
-                    .retrieve()
-                    .body(TourApiResponseDto.class);
+            try {
+                String json = restClient.get()
+                        .uri(buildListUrl(pageNo))
+                        .retrieve()
+                        .body(String.class);
 
-            if (response == null
-                    || response.getResponse() == null
-                    || response.getResponse().getBody() == null) {
-                log.warn("[AttractionApi] 응답 없음 — pageNo: {}", pageNo);
+                TourApiResponseDto response = objectMapper.readValue(json, TourApiResponseDto.class);
+
+                if (response == null
+                        || response.getResponse() == null
+                        || response.getResponse().getBody() == null) {
+                    log.warn("[AttractionApi] 응답 없음 — pageNo: {}", pageNo);
+                    break;
+                }
+
+                TourApiResponseDto.Body body = response.getResponse().getBody();
+                totalCount = body.getTotalCount();
+
+                if (body.getItems() == null || body.getItems().getItem() == null) {
+                    log.warn("[AttractionApi] 항목 없음 — pageNo: {}", pageNo);
+                    break;
+                }
+
+                List<Item> items = body.getItems().getItem();
+                log.info("[AttractionApi] pageNo={}, totalCount={}, 수신={}건", pageNo, totalCount, items.size());
+
+                for (Item item : items) {
+                    toAttraction(item).ifPresent(result::add);
+                }
+            } catch (Exception e) {
+                log.warn("[AttractionApi] 페이지 파싱 실패 pageNo={}: {}", pageNo, e.getMessage());
                 break;
-            }
-
-            TourApiResponseDto.Body body = response.getResponse().getBody();
-            totalCount = body.getTotalCount();
-
-            if (body.getItems() == null || body.getItems().getItem() == null) {
-                log.warn("[AttractionApi] 항목 없음 — pageNo: {}", pageNo);
-                break;
-            }
-
-            List<Item> items = body.getItems().getItem();
-            log.info("[AttractionApi] pageNo={}, totalCount={}, 수신={}건", pageNo, totalCount, items.size());
-
-            for (Item item : items) {
-                toAttraction(item).ifPresent(result::add);
             }
 
             pageNo++;
@@ -76,7 +91,7 @@ public class AttractionApiService {
         return result;
     }
 
-    private Optional<com.beyondtoursseoul.bts.domain.Attraction> toAttraction(Item item) {
+    private Optional<Attraction> toAttraction(Item item) {
         if (item.getMapX() == null || item.getMapX().isBlank()
                 || item.getMapY() == null || item.getMapY().isBlank()) {
             return Optional.empty();
@@ -85,20 +100,24 @@ public class AttractionApiService {
         try {
             double lng = Double.parseDouble(item.getMapX());
             double lat = Double.parseDouble(item.getMapY());
-
             if (lng == 0.0 || lat == 0.0) return Optional.empty();
 
             Point geom = GF.createPoint(new Coordinate(lng, lat));
 
             return Optional.of(
-                    com.beyondtoursseoul.bts.domain.Attraction.builder()
+                    Attraction.builder()
                             .externalId(item.getContentId())
                             .name(item.getTitle())
                             .category(item.getContentTypeId())
-                            .address(item.getAddr1())
+                            .address(blankToNull(item.getAddr1()))
                             .geom(geom)
                             .source(SOURCE)
                             .createdAt(OffsetDateTime.now())
+                            .thumbnail(blankToNull(item.getFirstImage()))
+                            .cat1(blankToNull(item.getCat1()))
+                            .cat2(blankToNull(item.getCat2()))
+                            .cat3(blankToNull(item.getCat3()))
+                            .tel(blankToNull(item.getTel()))
                             .build()
             );
         } catch (NumberFormatException e) {
@@ -107,7 +126,65 @@ public class AttractionApiService {
         }
     }
 
-    private String buildUrl(int pageNo) {
+    public record CommonDetail(String overview, String tel) {}
+
+    public CommonDetail fetchCommonDetail(String contentId) {
+        try {
+            String url = DETAIL_COMMON_URL
+                    + "?serviceKey=" + apiKey
+                    + "&MobileOS=ETC&MobileApp=BTS&_type=json"
+                    + "&contentId=" + contentId;
+
+            String json = restClient.get().uri(url).retrieve().body(String.class);
+            DetailCommonResponseDto response = objectMapper.readValue(json, DetailCommonResponseDto.class);
+
+            if (response == null
+                    || response.getResponse() == null
+                    || response.getResponse().getBody() == null
+                    || response.getResponse().getBody().getItems() == null
+                    || response.getResponse().getBody().getItems().getItem() == null
+                    || response.getResponse().getBody().getItems().getItem().isEmpty()) {
+                return new CommonDetail(null, null);
+            }
+            DetailCommonResponseDto.Item item = response.getResponse().getBody().getItems().getItem().get(0);
+            return new CommonDetail(blankToNull(item.getOverview()), blankToNull(item.getTel()));
+        } catch (Exception e) {
+            log.warn("[AttractionApi] detailCommon2 조회 실패 contentId={}: {}", contentId, e.getMessage());
+            return new CommonDetail(null, null);
+        }
+    }
+
+    public String fetchOperatingHours(String contentId, String contentTypeId) {
+        try {
+            String url = DETAIL_INTRO_URL
+                    + "?serviceKey=" + apiKey
+                    + "&MobileOS=ETC&MobileApp=BTS&_type=json"
+                    + "&contentId=" + contentId
+                    + "&contentTypeId=" + contentTypeId;
+
+            String json = restClient.get().uri(url).retrieve().body(String.class);
+            DetailInfoResponseDto response = objectMapper.readValue(json, DetailInfoResponseDto.class);
+
+            if (response == null
+                    || response.getResponse() == null
+                    || response.getResponse().getBody() == null
+                    || response.getResponse().getBody().getItems() == null
+                    || response.getResponse().getBody().getItems().getItem() == null
+                    || response.getResponse().getBody().getItems().getItem().isEmpty()) {
+                return null;
+            }
+            return response.getResponse().getBody().getItems().getItem().get(0).resolveOperatingHours();
+        } catch (Exception e) {
+            log.warn("[AttractionApi] 운영시간 조회 실패 contentId={}: {}", contentId, e.getMessage());
+            return null;
+        }
+    }
+
+    private static String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value;
+    }
+
+    private String buildListUrl(int pageNo) {
         return BASE_URL
                 + "?serviceKey=" + apiKey
                 + "&numOfRows=" + PAGE_SIZE

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
@@ -1,0 +1,90 @@
+package com.beyondtoursseoul.bts.service;
+
+import com.beyondtoursseoul.bts.domain.Attraction;
+import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
+import com.beyondtoursseoul.bts.dto.attraction.AttractionDetailResponse;
+import com.beyondtoursseoul.bts.dto.attraction.AttractionSummaryResponse;
+import com.beyondtoursseoul.bts.repository.AttractionLocalScoreRepository;
+import com.beyondtoursseoul.bts.repository.AttractionRepository;
+import com.beyondtoursseoul.bts.repository.TourCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AttractionQueryService {
+
+    private final AttractionRepository attractionRepository;
+    private final AttractionLocalScoreRepository scoreRepository;
+    private final TourCategoryRepository categoryRepository;
+    private final AttractionApiService attractionApiService;
+
+    public List<AttractionSummaryResponse> getList(LocalDate date, String timeSlot) {
+        LocalDate effectiveDate = date != null ? date
+                : scoreRepository.findLatestDate().orElse(LocalDate.now().minusDays(1));
+
+        Map<Long, AttractionLocalScore> scoreMap = scoreRepository
+                .findByIdDateAndIdTimeSlot(effectiveDate, timeSlot)
+                .stream()
+                .collect(Collectors.toMap(s -> s.getId().getAttractionId(), s -> s));
+
+        Map<String, String> categoryNames = categoryRepository.findAll()
+                .stream()
+                .collect(Collectors.toMap(c -> c.getCode(), c -> c.getName()));
+
+        return attractionRepository.findAll().stream()
+                .filter(a -> scoreMap.containsKey(a.getId()))
+                .map(a -> new AttractionSummaryResponse(
+                        a,
+                        scoreMap.get(a.getId()),
+                        categoryNames.getOrDefault(a.getCat1(), a.getCat1()),
+                        categoryNames.getOrDefault(a.getCat2(), a.getCat2()),
+                        categoryNames.getOrDefault(a.getCat3(), a.getCat3())
+                ))
+                .sorted(Comparator.comparing(AttractionSummaryResponse::getScore,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public AttractionDetailResponse getDetail(Long id) {
+        Attraction attraction = attractionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("관광지를 찾을 수 없습니다: " + id));
+
+        if (!attraction.isDetailFetched() && attraction.getExternalId() != null) {
+            AttractionApiService.CommonDetail common = attractionApiService.fetchCommonDetail(attraction.getExternalId());
+            String operatingHours = attractionApiService.fetchOperatingHours(
+                    attraction.getExternalId(), attraction.getCategory());
+            attraction.updateDetail(common.overview(), operatingHours, common.tel());
+        }
+
+        Map<String, String> categoryNames = categoryRepository.findAll()
+                .stream()
+                .collect(Collectors.toMap(c -> c.getCode(), c -> c.getName()));
+
+        Map<String, BigDecimal> scores = scoreRepository.findByIdAttractionId(id)
+                .stream()
+                .collect(Collectors.toMap(
+                        s -> s.getId().getTimeSlot(),
+                        AttractionLocalScore::getScore
+                ));
+
+        return new AttractionDetailResponse(
+                attraction,
+                categoryNames.getOrDefault(attraction.getCat1(), attraction.getCat1()),
+                categoryNames.getOrDefault(attraction.getCat2(), attraction.getCat2()),
+                categoryNames.getOrDefault(attraction.getCat3(), attraction.getCat3()),
+                scores
+        );
+    }
+}


### PR DESCRIPTION
## 개요

> 카테고리 코드→한글명 매핑 테이블을 구축하고, attraction 필드를 확장하여 목록/상세 조회 REST API를 구현한다.


## 변경 사항

> - `GET /api/attractions` — 찐로컬 지수 score 내림차순 관광지 목록 (thumbnail, 대/중/소분류명, address, 좌표, score)
> - `GET /api/attractions/{id}` — 관광지 상세 (기본 정보 + tel, overview, operatingHours, 시간대별 scores)
> - `tour_category` 테이블 도입: TourAPI `lclsSystmCode2`로 카테고리 코드→한글명 매핑 (`cat1/cat2/cat3` → `lclsSystm1/2/3` 전환)
> - overview/tel/operatingHours lazy loading: 첫 상세 요청 시 TourAPI fetch 후 DB 캐시 (`detail_fetched` 플래그)
> 

## 관련 이슈
close #58
