### PR TITLE
[DOCS] 관광지 목록/상세 조회 API Swagger 문서 추가

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
@@ -3,6 +3,11 @@ package com.beyondtoursseoul.bts.controller;
 import com.beyondtoursseoul.bts.dto.attraction.AttractionDetailResponse;
 import com.beyondtoursseoul.bts.dto.attraction.AttractionSummaryResponse;
 import com.beyondtoursseoul.bts.service.AttractionQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
+@Tag(name = "Attraction", description = "관광지 조회 API")
 @RestController
 @RequestMapping("/api/attractions")
 @RequiredArgsConstructor
@@ -18,15 +24,36 @@ public class AttractionController {
 
     private final AttractionQueryService attractionQueryService;
 
+    @Operation(
+            summary = "관광지 목록 조회",
+            description = "찐로컬 지수 score 내림차순으로 관광지 목록을 반환합니다. " +
+                          "date 미입력 시 가장 최근 점수 날짜를 자동으로 사용합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     @GetMapping
     public ResponseEntity<List<AttractionSummaryResponse>> getList(
+            @Parameter(description = "조회 날짜 (yyyy-MM-dd). 미입력 시 DB 최신 날짜 사용")
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @Parameter(description = "시간대. morning/lunch/afternoon/evening/night", example = "afternoon")
             @RequestParam(defaultValue = "afternoon") String timeSlot) {
         return ResponseEntity.ok(attractionQueryService.getList(date, timeSlot));
     }
 
+    @Operation(
+            summary = "관광지 상세 조회",
+            description = "관광지 상세 정보를 반환합니다. " +
+                          "overview·tel·operatingHours는 첫 요청 시 TourAPI에서 가져와 DB에 저장하며, " +
+                          "이후 요청부터는 캐시된 값을 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "관광지를 찾을 수 없음")
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<AttractionDetailResponse> getDetail(@PathVariable Long id) {
+    public ResponseEntity<AttractionDetailResponse> getDetail(
+            @Parameter(description = "관광지 ID") @PathVariable Long id) {
         return ResponseEntity.ok(attractionQueryService.getDetail(id));
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionDetailResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionDetailResponse.java
@@ -1,27 +1,53 @@
 package com.beyondtoursseoul.bts.dto.attraction;
 
 import com.beyondtoursseoul.bts.domain.Attraction;
-import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.util.Map;
 
 @Getter
+@Schema(description = "관광지 상세 정보")
 public class AttractionDetailResponse {
 
+    @Schema(description = "관광지 ID")
     private final Long id;
+
+    @Schema(description = "관광지명")
     private final String name;
+
+    @Schema(description = "대표 썸네일 이미지 URL")
     private final String thumbnail;
+
+    @Schema(description = "대분류명 (예: 문화관광)")
     private final String cat1Name;
+
+    @Schema(description = "중분류명 (예: 전시시설)")
     private final String cat2Name;
+
+    @Schema(description = "소분류명 (예: 기념관)")
     private final String cat3Name;
+
+    @Schema(description = "주소")
     private final String address;
+
+    @Schema(description = "경도")
     private final double lng;
+
+    @Schema(description = "위도")
     private final double lat;
+
+    @Schema(description = "전화번호")
     private final String tel;
+
+    @Schema(description = "관광지 소개글")
     private final String overview;
+
+    @Schema(description = "운영시간")
     private final String operatingHours;
+
+    @Schema(description = "시간대별 찐로컬 지수. key: morning/lunch/afternoon/evening/night, value: 0~1")
     private final Map<String, BigDecimal> scores;
 
     public AttractionDetailResponse(Attraction attraction,

--- a/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionSummaryResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionSummaryResponse.java
@@ -2,22 +2,43 @@ package com.beyondtoursseoul.bts.dto.attraction;
 
 import com.beyondtoursseoul.bts.domain.Attraction;
 import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.math.BigDecimal;
 
 @Getter
+@Schema(description = "관광지 목록 항목")
 public class AttractionSummaryResponse {
 
+    @Schema(description = "관광지 ID")
     private final Long id;
+
+    @Schema(description = "관광지명")
     private final String name;
+
+    @Schema(description = "대표 썸네일 이미지 URL")
     private final String thumbnail;
+
+    @Schema(description = "대분류명 (예: 문화관광)")
     private final String cat1Name;
+
+    @Schema(description = "중분류명 (예: 전시시설)")
     private final String cat2Name;
+
+    @Schema(description = "소분류명 (예: 기념관)")
     private final String cat3Name;
+
+    @Schema(description = "주소")
     private final String address;
+
+    @Schema(description = "경도")
     private final double lng;
+
+    @Schema(description = "위도")
     private final double lat;
+
+    @Schema(description = "해당 날짜·시간대의 찐로컬 지수 (0~1)")
     private final BigDecimal score;
 
     public AttractionSummaryResponse(Attraction attraction, AttractionLocalScore score,


### PR DESCRIPTION
## 개요
GET /api/attractions, GET /api/attractions/{id} 에 Swagger(@operation, @apiresponse 등) 설명이 없어
API 문서에서 용도와 파라미터 의미를 파악하기 어려움.
springdoc-openapi를 사용 중이므로 어노테이션 기반으로 문서화.

## 변경 사항

- AttractionController에 @tag 추가
- GET /api/attractions @operation 설명 추가 (date, timeSlot 파라미터 설명 포함)
- GET /api/attractions/{id} @operation 설명 추가
- 응답 필드(score, cat1Name 등) 의미 @Schema로 기술
- 404 등 에러 응답 @apiresponse 추가

## 관련 이슈
close #62
