### PR TITLE
refactor: 관광지 API 경로에 v1 버전 추가

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Tag(name = "Attraction", description = "관광지 조회 API")
 @RestController
-@RequestMapping("/api/attractions")
+@RequestMapping("/api/v1/attractions")
 @RequiredArgsConstructor
 public class AttractionController {
 


### PR DESCRIPTION
## 개요
> attraction의 api 형식을 타 api들과 동일하게 맞춘다.


## 변경 사항

- /api/attractions -> /api/v1/attractions 로 수정
- /api/attractions/{id} -> /api/v1/attractions/{id} 로 수정

## 관련 이슈
close #70
