### PR TITLE
[FIX] 관광지 상세 조회 시 시간대별 점수 Duplicate key 오류 수정

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/repository/AttractionLocalScoreRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/AttractionLocalScoreRepository.java
@@ -16,7 +16,7 @@ public interface AttractionLocalScoreRepository extends JpaRepository<Attraction
     @Query("SELECT MAX(a.id.date) FROM AttractionLocalScore a")
     Optional<LocalDate> findLatestDate();
 
-    List<AttractionLocalScore> findByIdAttractionId(Long attractionId);
+    List<AttractionLocalScore> findByIdAttractionIdAndIdDate(Long attractionId, LocalDate date);
 
     List<AttractionLocalScore> findByIdDateAndIdTimeSlot(LocalDate date, String timeSlot);
 }

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
@@ -72,7 +72,8 @@ public class AttractionQueryService {
                 .stream()
                 .collect(Collectors.toMap(c -> c.getCode(), c -> c.getName()));
 
-        Map<String, BigDecimal> scores = scoreRepository.findByIdAttractionId(id)
+        LocalDate latestDate = scoreRepository.findLatestDate().orElse(LocalDate.now().minusDays(1));
+        Map<String, BigDecimal> scores = scoreRepository.findByIdAttractionIdAndIdDate(id, latestDate)
                 .stream()
                 .collect(Collectors.toMap(
                         s -> s.getId().getTimeSlot(),


### PR DESCRIPTION
## 개요

> GET /api/v1/attractions/{id} 호출 시 500 오류 발생.
> 
> attraction_local_score 테이블에 동일 관광지의 날짜별 데이터가 누적되면, findByIdAttractionId()가 여러 날짜의 행을 모두 반환함.
> 같은 time_slot(afternoon 등)이 날짜 수만큼 중복되어 Collectors.toMap() 수집 시 Duplicate key 예외 발생.

## 변경 사항

> AttractionLocalScoreRepository에 findByIdAttractionIdAndIdDate() 추가
> 
> AttractionQueryService.getDetail()에서 최신 날짜로 필터링하여 조회

## 관련 이슈
close #73
