### PR TITLE
[FEAT] 서울 실시간 도시데이터 API 응답/저장 스키마 확정

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/domain/AreaCongestionRaw.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/AreaCongestionRaw.java
@@ -1,0 +1,84 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(
+        name = "area_congestion_raw",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_area_congestion_raw_area_code_population_time",
+                        columnNames = {"area_code", "population_time"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AreaCongestionRaw {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "area_code", nullable = false, length = 50)
+    private String areaCode;
+
+    @Column(name = "area_name", nullable = false, length = 100)
+    private String areaName;
+
+    @Column(name = "congestion_level", nullable = false, length = 50)
+    private String congestionLevel;
+
+    @Column(name = "congestion_message", columnDefinition = "text")
+    private String congestionMessage;
+
+    @Column(name = "population_min")
+    private Integer populationMin;
+
+    @Column(name = "population_max")
+    private Integer populationMax;
+
+    @Column(name = "population_time", nullable = false)
+    private LocalDateTime populationTime;
+
+    @Column(name = "forecast_yn", length = 1)
+    private String forecastYn;
+
+    @Column(name = "collected_at", nullable = false)
+    private OffsetDateTime collectedAt;
+
+    @Column(name = "raw_payload", columnDefinition = "text")
+    private String rawPayload;
+
+    @Builder
+    public AreaCongestionRaw(
+            String areaCode,
+            String areaName,
+            String congestionLevel,
+            String congestionMessage,
+            Integer populationMin,
+            Integer populationMax,
+            LocalDateTime populationTime,
+            String forecastYn,
+            OffsetDateTime collectedAt,
+            String rawPayload
+    ) {
+        this.areaCode = areaCode;
+        this.areaName = areaName;
+        this.congestionLevel = congestionLevel;
+        this.congestionMessage = congestionMessage;
+        this.populationMin = populationMin;
+        this.populationMax = populationMax;
+        this.populationTime = populationTime;
+        this.forecastYn = forecastYn;
+        this.collectedAt = collectedAt;
+        this.rawPayload = rawPayload;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/CityDataApiResponseDto.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/CityDataApiResponseDto.java
@@ -1,0 +1,86 @@
+package com.beyondtoursseoul.bts.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CityDataApiResponseDto {
+
+    @JsonProperty("list_total_count")
+    private int listTotalCount;
+
+    @JsonProperty("CITYDATA")
+    private CityData cityData;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CityData {
+
+        @JsonProperty("AREA_NM")
+        private String areaName;
+
+        @JsonProperty("AREA_CD")
+        private String areaCode;
+
+        @JsonProperty("LIVE_PPLTN_STTS")
+        private List<LivePopulationStatus> livePopulationStatuses;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LivePopulationStatus {
+
+        @JsonProperty("AREA_NM")
+        private String areaName;
+
+        @JsonProperty("AREA_CD")
+        private String areaCode;
+
+        @JsonProperty("AREA_CONGEST_LVL")
+        private String congestionLevel;
+
+        @JsonProperty("AREA_CONGEST_MSG")
+        private String congestionMessage;
+
+        @JsonProperty("AREA_PPLTN_MIN")
+        private String areaPpltnMin;
+
+        @JsonProperty("AREA_PPLTN_MAX")
+        private String areaPpltnMax;
+
+        @JsonProperty("PPLTN_TIME")
+        private String populationTime;
+
+        @JsonProperty("FCST_YN")
+        private String forecastYn;
+
+        @JsonProperty("FCST_PPLTN")
+        private List<ForecastPopulation> forecastPopulations;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ForecastPopulation {
+
+        @JsonProperty("FCST_TIME")
+        private String forecastTime;
+
+        @JsonProperty("FCST_CONGEST_LVL")
+        private String forecastCongestionLevel;
+
+        @JsonProperty("FCST_PPLTN_MIN")
+        private String forecastPpltnMin;
+
+        @JsonProperty("FCST_PPLTN_MAX")
+        private String forecastPpltnMax;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/repository/AreaCongestionRawRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/AreaCongestionRawRepository.java
@@ -1,0 +1,19 @@
+package com.beyondtoursseoul.bts.repository;
+
+import com.beyondtoursseoul.bts.domain.AreaCongestionRaw;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface AreaCongestionRawRepository extends JpaRepository<AreaCongestionRaw, Long> {
+
+    boolean existsByAreaCodeAndPopulationTime(String areaCode, LocalDateTime populationTime);
+
+    Optional<AreaCongestionRaw> findByAreaCodeAndPopulationTime(String areaCode, LocalDateTime populationTime);
+
+    List<AreaCongestionRaw> findTop100ByOrderByCollectedAtDesc();
+
+    List<AreaCongestionRaw> findByAreaCodeOrderByPopulationTimeDesc(String areaCode);
+}

--- a/src/main/java/com/beyondtoursseoul/bts/runner/CityDataSampleRunner.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/CityDataSampleRunner.java
@@ -1,0 +1,65 @@
+package com.beyondtoursseoul.bts.runner;
+
+import com.beyondtoursseoul.bts.domain.AreaCongestionRaw;
+import com.beyondtoursseoul.bts.repository.AreaCongestionRawRepository;
+import com.beyondtoursseoul.bts.service.AreaCongestionCollectService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(1)
+public class CityDataSampleRunner implements ApplicationRunner {
+
+    private static final String SAMPLE_AREA_NAME = "광화문·덕수궁";
+    private static final String SAMPLE_AREA_CODE = "POI009";
+
+    private final AreaCongestionCollectService areaCongestionCollectService;
+    private final AreaCongestionRawRepository areaCongestionRawRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!args.containsOption("citydata-collect-sample")) {
+            return;
+        }
+
+        log.info("[CityDataSampleRunner] citydata collect sample start. areaName={}", SAMPLE_AREA_NAME);
+
+        try {
+            areaCongestionCollectService.collectOne(SAMPLE_AREA_NAME);
+
+            List<AreaCongestionRaw> rows =
+                    areaCongestionRawRepository.findByAreaCodeOrderByPopulationTimeDesc(SAMPLE_AREA_CODE);
+
+            if (rows.isEmpty()) {
+                log.warn("[CityDataSampleRunner] no saved row found. areaCode={}", SAMPLE_AREA_CODE);
+                return;
+            }
+
+            logSavedRow(rows.get(0));
+
+        } catch (Exception e) {
+            log.error("[CityDataSampleRunner] citydata collect sample failed", e);
+        }
+    }
+
+    private void logSavedRow(AreaCongestionRaw row) {
+        log.info("[CityDataSampleRunner] saved row id={}", row.getId());
+        log.info("[CityDataSampleRunner] areaCode={}", row.getAreaCode());
+        log.info("[CityDataSampleRunner] areaName={}", row.getAreaName());
+        log.info("[CityDataSampleRunner] congestionLevel={}", row.getCongestionLevel());
+        log.info("[CityDataSampleRunner] congestionMessage={}", row.getCongestionMessage());
+        log.info("[CityDataSampleRunner] populationMin={}", row.getPopulationMin());
+        log.info("[CityDataSampleRunner] populationMax={}", row.getPopulationMax());
+        log.info("[CityDataSampleRunner] populationTime={}", row.getPopulationTime());
+        log.info("[CityDataSampleRunner] forecastYn={}", row.getForecastYn());
+        log.info("[CityDataSampleRunner] collectedAt={}", row.getCollectedAt());
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/AreaCongestionCollectService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AreaCongestionCollectService.java
@@ -1,0 +1,111 @@
+package com.beyondtoursseoul.bts.service;
+
+import com.beyondtoursseoul.bts.domain.AreaCongestionRaw;
+import com.beyondtoursseoul.bts.dto.CityDataApiResponseDto;
+import com.beyondtoursseoul.bts.repository.AreaCongestionRawRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AreaCongestionCollectService {
+
+    private static final DateTimeFormatter POPULATION_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    private final SeoulCityDataApiService seoulCityDataApiService;
+    private final AreaCongestionRawRepository areaCongestionRawRepository;
+
+    @Transactional
+    public void collectOne(String areaName) {
+        log.info("[AreaCongestionCollectService] collect start. areaName={}", areaName);
+
+        CityDataApiResponseDto response = seoulCityDataApiService.fetchByArea(areaName);
+
+        if (response == null || response.getCityData() == null) {
+            log.warn("[AreaCongestionCollectService] cityData is null. areaName={}", areaName);
+            return;
+        }
+
+        if (response.getCityData().getLivePopulationStatuses() == null
+                || response.getCityData().getLivePopulationStatuses().isEmpty()) {
+            log.warn("[AreaCongestionCollectService] livePopulationStatuses is empty. areaName={}", areaName);
+            return;
+        }
+
+        CityDataApiResponseDto.CityData cityData = response.getCityData();
+        CityDataApiResponseDto.LivePopulationStatus status = cityData.getLivePopulationStatuses().get(0);
+
+        LocalDateTime populationTime = parsePopulationTime(status.getPopulationTime());
+        Integer populationMin = parseInteger(status.getAreaPpltnMin());
+        Integer populationMax = parseInteger(status.getAreaPpltnMax());
+
+        boolean exists = areaCongestionRawRepository.existsByAreaCodeAndPopulationTime(
+                cityData.getAreaCode(),
+                populationTime
+        );
+
+        if (exists) {
+            log.info("[AreaCongestionCollectService] already exists. areaCode={}, populationTime={}",
+                    cityData.getAreaCode(), populationTime);
+            return;
+        }
+
+        AreaCongestionRaw entity = AreaCongestionRaw.builder()
+                .areaCode(cityData.getAreaCode())
+                .areaName(cityData.getAreaName())
+                .congestionLevel(status.getCongestionLevel())
+                .congestionMessage(status.getCongestionMessage())
+                .populationMin(populationMin)
+                .populationMax(populationMax)
+                .populationTime(populationTime)
+                .forecastYn(status.getForecastYn())
+                .collectedAt(OffsetDateTime.now())
+                .rawPayload(null)
+                .build();
+
+        areaCongestionRawRepository.save(entity);
+
+        log.info("[AreaCongestionCollectService] collect success. areaCode={}, populationTime={}",
+                entity.getAreaCode(), entity.getPopulationTime());
+
+    }
+
+    private LocalDateTime parsePopulationTime(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("populationTime is blank");
+        }
+        return LocalDateTime.parse(value, POPULATION_TIME_FORMATTER);
+    }
+
+    private Integer parseInteger(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return Integer.parseInt(value);
+    }
+
+    @Transactional
+    public void collectAll() {
+        List<String> targetAreas = List.of(
+                "광화문·덕수궁"
+                // TODO: 나머지 장소 추가
+        );
+
+        for (String areaName : targetAreas) {
+            try {
+                collectOne(areaName);
+            } catch (Exception e) {
+                log.error("[AreaCongestionCollectService] collect failed. areaName={}", areaName, e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/SeoulCityDataApiService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/SeoulCityDataApiService.java
@@ -1,0 +1,37 @@
+package com.beyondtoursseoul.bts.service;
+
+import com.beyondtoursseoul.bts.dto.CityDataApiResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Service
+public class SeoulCityDataApiService {
+
+    private static final String SERVICE_NAME = "citydata"; // TODO: 실제 서비스명 최종 확인
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${SEOUL_OPEN_API_KEY}")
+    private String apiKey;
+
+    public CityDataApiResponseDto fetchByArea(String areaName) {
+        String url = buildUrl(areaName);
+        log.info("Calling Seoul citydata API. area={}, url={}", areaName, url);
+
+        return restClient.get()
+                .uri(url)
+                .retrieve()
+                .body(CityDataApiResponseDto.class);
+    }
+
+    private String buildUrl(String areaName) {
+        return String.format(
+                "http://openapi.seoul.go.kr:8088/%s/json/%s/1/5/%s",
+                apiKey,
+                SERVICE_NAME,
+                areaName
+        );
+    }
+}

--- a/src/main/resources/sql/area_congestion_raw.sql
+++ b/src/main/resources/sql/area_congestion_raw.sql
@@ -1,0 +1,19 @@
+-- Manual DDL for the first Seoul citydata congestion collection schema.
+-- Apply this in Supabase SQL Editor (or PostgreSQL) before running
+-- the area congestion sample collector with ddl-auto=none.
+
+create table if not exists public.area_congestion_raw (
+    id bigserial primary key,
+    area_code varchar(50) not null,
+    area_name varchar(100) not null,
+    congestion_level varchar(50) not null,
+    congestion_message text,
+    population_min integer,
+    population_max integer,
+    population_time timestamp not null,
+    forecast_yn varchar(1),
+    collected_at timestamptz not null,
+    raw_payload text,
+    constraint uk_area_congestion_raw_area_code_population_time
+        unique (area_code, population_time)
+);


### PR DESCRIPTION
## 개요
서울시 실시간 도시데이터 API의 실제 응답 구조를 기준으로 혼잡도 수집용 DTO와 저장 스키마 확정

## 변경 사항
- citydata API 응답 구조에 맞춰 DTO 정리
- `AreaCongestionRaw` 엔티티 / Repository 추가
- 샘플 수집 및 저장 검증용 Service / Runner 추가
- `area_congestion_raw` 수동 생성용 SQL 추가

## 테스트
- [x] `광화문·덕수궁` 샘플 호출 성공
- [x] `area_congestion_raw` 테이블 insert 성공
- [x] 저장 후 재조회 성공
- [x] `./gradlew compileJava` 

## 관련 이슈
close #76
