### PR TITLE
[FEAT] 서울 실시간 혼잡도 수집 배치 구현

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/runner/CityDataSampleRunner.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/CityDataSampleRunner.java
@@ -33,7 +33,7 @@ public class CityDataSampleRunner implements ApplicationRunner {
         log.info("[CityDataSampleRunner] citydata collect sample start. areaName={}", SAMPLE_AREA_NAME);
 
         try {
-            areaCongestionCollectService.collectOne(SAMPLE_AREA_NAME);
+            areaCongestionCollectService.collectAll();
 
             List<AreaCongestionRaw> rows =
                     areaCongestionRawRepository.findByAreaCodeOrderByPopulationTimeDesc(SAMPLE_AREA_CODE);

--- a/src/main/java/com/beyondtoursseoul/bts/service/AreaCongestionCollectService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AreaCongestionCollectService.java
@@ -24,21 +24,27 @@ public class AreaCongestionCollectService {
     private final SeoulCityDataApiService seoulCityDataApiService;
     private final AreaCongestionRawRepository areaCongestionRawRepository;
 
+    public enum CollectResult {
+        SUCCESS,
+        SKIPPED,
+        FAILED
+    }
+
     @Transactional
-    public void collectOne(String areaName) {
+    public CollectResult collectOne(String areaName) {
         log.info("[AreaCongestionCollectService] collect start. areaName={}", areaName);
 
         CityDataApiResponseDto response = seoulCityDataApiService.fetchByArea(areaName);
 
         if (response == null || response.getCityData() == null) {
             log.warn("[AreaCongestionCollectService] cityData is null. areaName={}", areaName);
-            return;
+            return CollectResult.FAILED;
         }
 
         if (response.getCityData().getLivePopulationStatuses() == null
                 || response.getCityData().getLivePopulationStatuses().isEmpty()) {
             log.warn("[AreaCongestionCollectService] livePopulationStatuses is empty. areaName={}", areaName);
-            return;
+            return CollectResult.FAILED;
         }
 
         CityDataApiResponseDto.CityData cityData = response.getCityData();
@@ -56,7 +62,7 @@ public class AreaCongestionCollectService {
         if (exists) {
             log.info("[AreaCongestionCollectService] already exists. areaCode={}, populationTime={}",
                     cityData.getAreaCode(), populationTime);
-            return;
+            return CollectResult.SKIPPED;
         }
 
         AreaCongestionRaw entity = AreaCongestionRaw.builder()
@@ -77,6 +83,7 @@ public class AreaCongestionCollectService {
         log.info("[AreaCongestionCollectService] collect success. areaCode={}, populationTime={}",
                 entity.getAreaCode(), entity.getPopulationTime());
 
+        return CollectResult.SUCCESS;
     }
 
     private LocalDateTime parsePopulationTime(String value) {
@@ -95,17 +102,38 @@ public class AreaCongestionCollectService {
 
     @Transactional
     public void collectAll() {
-        List<String> targetAreas = List.of(
-                "광화문·덕수궁"
-                // TODO: 나머지 장소 추가
+        List<String> TARGET_AREAS = List.of(
+                "광화문·덕수궁",
+                "강남역",
+                "명동 관광특구"
         );
 
-        for (String areaName : targetAreas) {
+        int total = TARGET_AREAS.size();
+        int successCount = 0;
+        int skippedCount = 0;
+        int failedCount = 0;
+
+        for (String areaName : TARGET_AREAS) {
             try {
-                collectOne(areaName);
+                CollectResult result = collectOne(areaName);
+
+                switch(result) {
+                    case SUCCESS -> successCount++;
+                    case SKIPPED -> skippedCount++;
+                    case FAILED -> failedCount++;
+                }
             } catch (Exception e) {
+                failedCount++;
                 log.error("[AreaCongestionCollectService] collect failed. areaName={}", areaName, e);
             }
         }
+
+        log.info(
+                "[AreaCongestionCollectService] collectAll finished. total={}, success={}, skipped={}, failed={}",
+                total,
+                successCount,
+                skippedCount,
+                failedCount
+        );
     }
 }


### PR DESCRIPTION
## 개요
서울시 실시간 도시데이터 API를 기반으로, 혼잡도 수집 대상을 순회하며 `area_congestion_raw` 테이블에 저장하는 배치 로직을 구현

## 변경 사항
- 혼잡도 수집 대상 지역 목록 추가
- `collectAll()` 기반 다건 수집 흐름 구현
- `collectOne()` 결과를 `SUCCESS / SKIPPED / FAILED` 로 구분하도록 변경
- 배치 실행 결과 요약 로그 추가
- 샘플 다건 호출 기준 저장 검증 완료

## 테스트
- [x] `./gradlew compileJava`
- [x] `광화문·덕수궁`, `강남역`, `명동 관광특구` 순회 호출 성공
- [x] `area_congestion_raw` 다건 insert 성공
- [x] `collectAll finished. total=3, success=3, skipped=0, failed=0` 로그 확인

## 관련 이슈
close #81 
