### PR TITLE
[FEAT] 관광지 찐로컬 지수 보정: 카테고리 계수 + 관광 클러스터 proximity penalty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+	// IQR/median 계산 (repeat 지표)
+	implementation 'org.apache.commons:commons-math3:3.6.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/beyondtoursseoul/bts/repository/AttractionLocalScoreRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/AttractionLocalScoreRepository.java
@@ -11,8 +11,6 @@ import java.util.Optional;
 
 public interface AttractionLocalScoreRepository extends JpaRepository<AttractionLocalScore, AttractionLocalScoreId> {
 
-    boolean existsByIdDate(LocalDate date);
-
     @Query("SELECT MAX(a.id.date) FROM AttractionLocalScore a")
     Optional<LocalDate> findLatestDate();
 

--- a/src/main/java/com/beyondtoursseoul/bts/service/score/AttractionScoreService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/score/AttractionScoreService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDate;
 
@@ -14,34 +15,97 @@ import java.time.LocalDate;
 public class AttractionScoreService {
 
     private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
     private final AttractionLocalScoreRepository repository;
 
+    // 카테고리별 보정 계수 — 관광객 유입 가능성이 높은 카테고리는 하향
+    private static final String CATEGORY_FACTOR_CASE = """
+            CASE a.category
+                WHEN '12' THEN 0.85
+                WHEN '14' THEN 0.85
+                WHEN '32' THEN 0.75
+                ELSE 1.0
+            END
+            """;
+
+    // 주요 관광 클러스터 (lng, lat) — 명동/인사동/홍대/이태원/남산/경복궁/동대문/코엑스
+    private static final String TOURIST_CLUSTERS_VALUES = """
+            (126.9836, 37.5635),
+            (126.9851, 37.5745),
+            (126.9218, 37.5565),
+            (126.9944, 37.5344),
+            (126.9882, 37.5512),
+            (126.9770, 37.5796),
+            (127.0095, 37.5710),
+            (127.0590, 37.5113)
+            """;
+
+    // 동시 실행 방지용 advisory lock 키 (임의 고정 값)
+    private static final long ADVISORY_LOCK_KEY = 20260101L;
+
     public void calculateAndSave(LocalDate date) {
-        if (repository.existsByIdDate(date)) {
+        boolean alreadyDone = repository.findLatestDate()
+                .map(latest -> !latest.isBefore(date))
+                .orElse(false);
+        if (alreadyDone) {
             log.info("[AttractionScore] {} 이미 계산됨 — 스킵", date);
             return;
         }
 
-        int total = 0;
-        for (TimeSlot timeSlot : TimeSlot.values()) {
-            int count = insertForTimeSlot(date, timeSlot);
-            total += count;
-            log.info("[AttractionScore] {} {} — {}건 저장", date, timeSlot.getCode(), count);
+        // 이전 세션이 아직 INSERT 중이면 즉시 포기 (데드락 방지)
+        Boolean locked = jdbcTemplate.queryForObject(
+                "SELECT pg_try_advisory_lock(?)", Boolean.class, ADVISORY_LOCK_KEY);
+        if (!Boolean.TRUE.equals(locked)) {
+            log.warn("[AttractionScore] 다른 세션이 계산 중 — 스킵 (date={})", date);
+            return;
         }
 
-        log.info("[AttractionScore] 완료: {} 총 {}건", date, total);
+        try {
+            int total = 0;
+            for (TimeSlot timeSlot : TimeSlot.values()) {
+                int count = insertForTimeSlot(date, timeSlot);
+                total += count;
+                log.info("[AttractionScore] {} {} — {}건 저장", date, timeSlot.getCode(), count);
+            }
+            log.info("[AttractionScore] 완료: {} 총 {}건", date, total);
+        } finally {
+            jdbcTemplate.queryForObject("SELECT pg_advisory_unlock(?)", Boolean.class, ADVISORY_LOCK_KEY);
+        }
     }
 
     private int insertForTimeSlot(LocalDate date, TimeSlot timeSlot) {
-        return jdbcTemplate.update("""
+        String insertSql = """
                 INSERT INTO attraction_local_score (attraction_id, date, time_slot, hour, score)
-                SELECT a.id, ?, ?, ?, s.score
+                SELECT a.id, ?, ?, ?,
+                    LEAST(1.0, GREATEST(0.0,
+                        (SUM(s.score / GREATEST(ST_Distance(a.geom::geography, ST_Centroid(d.geom)::geography), 1.0)^2)
+                         / SUM(1.0   / GREATEST(ST_Distance(a.geom::geography, ST_Centroid(d.geom)::geography), 1.0)^2))
+                        * (%s)
+                        * MAX(tc.proximity_factor)
+                    ))
                 FROM attraction a
-                JOIN dong_local_score s ON s.dong_code = a.dong_code
+                JOIN dong_boundary d ON ST_DWithin(a.geom::geography, d.geom::geography, 1000)
+                JOIN dong_local_score s ON s.dong_code = d.dong_code,
+                LATERAL (
+                    SELECT 0.5 + 0.5 * (1 - EXP(-MIN(ST_Distance(
+                            a.geom::geography,
+                            ST_SetSRID(ST_MakePoint(c.lng, c.lat), 4326)::geography
+                        )) / 2000.0)) AS proximity_factor
+                    FROM (VALUES %s) AS c(lng, lat)
+                ) tc
                 WHERE s.date = ? AND s.time_slot = ?
-                  AND a.dong_code IS NOT NULL
-                ON CONFLICT (attraction_id, date, time_slot) DO UPDATE SET score = EXCLUDED.score
-                """, date, timeSlot.getCode(), timeSlot.getStartHour(), date, timeSlot.getCode());
+                  AND d.geom IS NOT NULL
+                GROUP BY a.id
+                """.formatted(CATEGORY_FACTOR_CASE, TOURIST_CLUSTERS_VALUES);
+
+        Integer count = transactionTemplate.execute(status -> {
+            jdbcTemplate.update(
+                    "DELETE FROM attraction_local_score WHERE date = ? AND time_slot = ?",
+                    date, timeSlot.getCode());
+            return jdbcTemplate.update(insertSql,
+                    date, timeSlot.getCode(), timeSlot.getStartHour(), date, timeSlot.getCode());
+        });
+        return count != null ? count : 0;
     }
 
     // Approach C: contentTypeId 기준 대표 시간대

--- a/src/main/java/com/beyondtoursseoul/bts/service/score/LocalScoreCalculateService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/score/LocalScoreCalculateService.java
@@ -6,6 +6,7 @@ import com.beyondtoursseoul.bts.repository.DongLocalScoreRepository;
 import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import tools.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,13 +46,16 @@ public class LocalScoreCalculateService {
             return;
         }
 
-        // 과거 4주치 원시 데이터 (stability, repeat 계산용)
         List<DongPopulationRaw> historyList = rawRepository.findByTimeSlotAndDateBetween(
                 slot.getCode(), historyFrom, targetDate);
         Map<String, List<DongPopulationRaw>> historyByDong = historyList.stream()
                 .collect(Collectors.groupingBy(DongPopulationRaw::getDongCode));
 
+        // Task 1: foreign_penalty 선계산 (4주 평균 기반 z-score → sigmoid)
+        Map<String, Double> foreignPenaltyMap = computeForeignPenalty(currentList, historyByDong);
+
         // 행정동별 원시 지표 계산
+        // [0]=local_ratio, [1]=stability, [2]=repeat, [3]=foreign_penalty_sigmoid
         Map<String, double[]> rawMetrics = new LinkedHashMap<>();
         for (DongPopulationRaw current : currentList) {
             String dongCode = current.getDongCode();
@@ -62,38 +66,38 @@ public class LocalScoreCalculateService {
             double total = korean + foreign;
 
             double localRatio     = total > 0 ? korean / total : 0.5;
-            double foreignPenalty = total > 0 ? foreign / total : 0.5;
             double stability      = calculateStability(history);
             double repeat         = calculateRepeat(history);
+            double foreignPenalty = foreignPenaltyMap.getOrDefault(dongCode, 0.5);
 
-            // [0]=local_ratio, [1]=stability, [2]=repeat, [3]=foreign_penalty
             rawMetrics.put(dongCode, new double[]{localRatio, stability, repeat, foreignPenalty});
         }
 
-        // MIN-MAX 정규화 (서울 전체 행정동 기준)
-        double[] mins = {Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE};
-        double[] maxs = {-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE};
+        // MIN-MAX 정규화 (인덱스 0~2: localRatio, stability, repeat)
+        // foreignPenalty(인덱스 3)는 sigmoid로 이미 (0,1) 범위 — 직접 사용
+        double[] mins = {Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE};
+        double[] maxs = {-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE};
         for (double[] m : rawMetrics.values()) {
-            for (int i = 0; i < 4; i++) {
+            for (int i = 0; i < 3; i++) {
                 if (m[i] < mins[i]) mins[i] = m[i];
                 if (m[i] > maxs[i]) maxs[i] = m[i];
             }
         }
 
-        // 기존 점수 삭제 후 재계산
         scoreRepository.deleteByDateAndTimeSlot(targetDate, slot.getCode());
 
         List<DongLocalScore> scores = new ArrayList<>();
         for (Map.Entry<String, double[]> entry : rawMetrics.entrySet()) {
             double[] m = entry.getValue();
-            double[] norm = new double[4];
-            for (int i = 0; i < 4; i++) {
+            double[] norm = new double[3];
+            for (int i = 0; i < 3; i++) {
                 double range = maxs[i] - mins[i];
                 norm[i] = range > 1e-9 ? (m[i] - mins[i]) / range : 0.0;
             }
 
-            double score = 0.3 * norm[0] + 0.3 * norm[1] + 0.3 * norm[2] - 0.1 * norm[3];
-            score = Math.max(0.0, Math.min(1.0, score));
+            // m[3] = sigmoid(foreignZ): 서울 평균 동이면 0.5, 외국인 많을수록 1에 가까움
+            double score = 0.3 * norm[0] + 0.3 * norm[1] + 0.3 * norm[2] - 0.1 * m[3];
+            score = Math.max(0.0, Math.min(1.0, score / 0.9));
 
             scores.add(DongLocalScore.builder()
                     .dongCode(entry.getKey())
@@ -108,7 +112,36 @@ public class LocalScoreCalculateService {
         log.info("time_slot {} 저장 완료: {}개 행정동", slot.getCode(), scores.size());
     }
 
-    // stability = 1 - |평일평균 - 주말평균| / MAX(평일평균, 주말평균)
+    // Task 1: 동별 4주 평균 외국인 인구 기반 z-score → sigmoid
+    private Map<String, Double> computeForeignPenalty(
+            List<DongPopulationRaw> currentList,
+            Map<String, List<DongPopulationRaw>> historyByDong) {
+
+        Map<String, Double> dongForeignAvg = new LinkedHashMap<>();
+        for (DongPopulationRaw current : currentList) {
+            String dongCode = current.getDongCode();
+            List<DongPopulationRaw> history = historyByDong.getOrDefault(dongCode, List.of(current));
+            double avg = history.stream()
+                    .mapToDouble(r -> r.getForeignPop().doubleValue())
+                    .average().orElse(0.0);
+            dongForeignAvg.put(dongCode, avg);
+        }
+
+        double[] values = dongForeignAvg.values().stream().mapToDouble(v -> v).toArray();
+        double mean = Arrays.stream(values).average().orElse(0.0);
+        double variance = Arrays.stream(values).map(v -> Math.pow(v - mean, 2)).average().orElse(0.0);
+        double stddev = Math.sqrt(variance);
+
+        Map<String, Double> result = new LinkedHashMap<>();
+        for (Map.Entry<String, Double> entry : dongForeignAvg.entrySet()) {
+            double z = stddev > 1e-9 ? (entry.getValue() - mean) / stddev : 0.0;
+            result.put(entry.getKey(), 1.0 / (1.0 + Math.exp(-z)));
+        }
+        return result;
+    }
+
+    // stability = 1 - |평일평균 - 주말평균| / (MAX(평일평균, 주말평균) + 500)
+    // 500: 소규모 동(min ~2,400명)에서 분모 폭발 방지, 중간 이상 동엔 영향 미미
     private double calculateStability(List<DongPopulationRaw> history) {
         List<Double> weekday = new ArrayList<>();
         List<Double> weekend = new ArrayList<>();
@@ -129,23 +162,21 @@ public class LocalScoreCalculateService {
         double weAvg = weekend.stream().mapToDouble(d -> d).average().orElse(0);
         double maxAvg = Math.max(wdAvg, weAvg);
 
-        return maxAvg > 0 ? 1.0 - Math.abs(wdAvg - weAvg) / maxAvg : 1.0;
+        return 1.0 - Math.abs(wdAvg - weAvg) / (maxAvg + 500);
     }
 
-    // repeat = 1 / (1 + 변동계수)  변동계수 = 표준편차 / 평균
+    // Task 3: CV 기반 → IQR/median 기반 (저인구 동의 CV 폭발 문제 해소)
     private double calculateRepeat(List<DongPopulationRaw> history) {
         if (history.size() < 2) return 1.0;
 
-        double[] pops = history.stream()
-                .mapToDouble(r -> r.getKoreanPop().doubleValue())
-                .toArray();
-        double mean = Arrays.stream(pops).average().orElse(0);
-        if (mean < 1e-9) return 1.0;
+        DescriptiveStatistics stats = new DescriptiveStatistics();
+        history.forEach(r -> stats.addValue(r.getKoreanPop().doubleValue()));
 
-        double variance = Arrays.stream(pops).map(p -> Math.pow(p - mean, 2)).average().orElse(0);
-        double cv = Math.sqrt(variance) / mean;
+        double median = stats.getPercentile(50);
+        if (median < 1e-9) return 1.0;
 
-        return 1.0 / (1.0 + cv);
+        double iqr = stats.getPercentile(75) - stats.getPercentile(25);
+        return 1.0 / (1.0 + iqr / median);
     }
 
     private String buildBreakdown(String timeSlot, double[] raw, double[] norm) {
@@ -155,11 +186,10 @@ public class LocalScoreCalculateService {
             map.put("local_ratio", round4(raw[0]));
             map.put("stability", round4(raw[1]));
             map.put("repeat", round4(raw[2]));
-            map.put("foreign_penalty", round4(raw[3]));
+            map.put("foreign_penalty_sigmoid", round4(raw[3]));
             map.put("local_ratio_norm", round4(norm[0]));
             map.put("stability_norm", round4(norm[1]));
             map.put("repeat_norm", round4(norm[2]));
-            map.put("foreign_penalty_norm", round4(norm[3]));
             return objectMapper.writeValueAsString(map);
         } catch (Exception e) {
             return "{}";


### PR DESCRIPTION
## 개요

- 찐로컬 지수 공식 고도화 (foreign_penalty/stability/repeat)
- 관광지 점수 IDW 블렌딩 + 카테고리 보정 + 데드락 방지
- 

## 변경 사항
 - foreign_penalty: local_ratio 중복 항 → 4주 평균 외국인 인구 z-score + sigmoid
  - stability: 분모 +500 smoothing으로 소규모 동 CV 폭발 방지
  - repeat: CV 기반 → IQR/median 기반으로 교체
  - commons-math3 의존성 추가"

  - IDW: 반경 1km 내 행정동 거리^2 역수 가중평균 (관광특구 0점 고착 해소)
  - 카테고리 보정 계수: 관광지/문화시설 0.85, 숙박 0.75
  - 관광클러스터 proximity 패널티 (명동/인사동/홍대 등 8곳)
  - ON CONFLICT → DELETE+INSERT+TransactionTemplate으로 데드락 제거
  - pg_try_advisory_lock으로 PgBouncer 환경 동시 실행 방지
  - existsByIdDate → findLatestDate() 기반으로 교체"

## 테스트

## 관련 이슈
close #77
