### PR TITLE
[REFACTOR] GET /api/v1/attractions/{id} 응답 null 처리 개

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionDetailResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionDetailResponse.java
@@ -3,6 +3,7 @@ package com.beyondtoursseoul.bts.dto.attraction;
 import com.beyondtoursseoul.bts.domain.Attraction;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import org.locationtech.jts.geom.Point;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -47,12 +48,19 @@ public class AttractionDetailResponse {
     @Schema(description = "운영시간")
     private final String operatingHours;
 
+    @Schema(description = "찐로컬 지수 데이터 존재 여부. false면 scores는 빈 Map")
+    private final boolean scoresAvailable;
+
     @Schema(description = "시간대별 찐로컬 지수. key: morning/lunch/afternoon/evening/night, value: 0~1")
     private final Map<String, BigDecimal> scores;
 
     public AttractionDetailResponse(Attraction attraction,
                                     String cat1Name, String cat2Name, String cat3Name,
                                     Map<String, BigDecimal> scores) {
+        Point geom = attraction.getGeom();
+        if (geom == null) {
+            throw new IllegalStateException("관광지 좌표 데이터가 없습니다: id=" + attraction.getId());
+        }
         this.id = attraction.getId();
         this.name = attraction.getName();
         this.thumbnail = attraction.getThumbnail();
@@ -60,11 +68,12 @@ public class AttractionDetailResponse {
         this.cat2Name = cat2Name;
         this.cat3Name = cat3Name;
         this.address = attraction.getAddress();
-        this.lng = attraction.getGeom().getX();
-        this.lat = attraction.getGeom().getY();
+        this.lng = geom.getX();
+        this.lat = geom.getY();
         this.tel = attraction.getTel();
         this.overview = attraction.getOverview();
         this.operatingHours = attraction.getOperatingHours();
+        this.scoresAvailable = scores != null && !scores.isEmpty();
         this.scores = scores;
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionSummaryResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionSummaryResponse.java
@@ -4,6 +4,7 @@ import com.beyondtoursseoul.bts.domain.Attraction;
 import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import org.locationtech.jts.geom.Point;
 
 import java.math.BigDecimal;
 
@@ -43,6 +44,10 @@ public class AttractionSummaryResponse {
 
     public AttractionSummaryResponse(Attraction attraction, AttractionLocalScore score,
                                      String cat1Name, String cat2Name, String cat3Name) {
+        Point geom = attraction.getGeom();
+        if (geom == null) {
+            throw new IllegalStateException("관광지 좌표 데이터가 없습니다: id=" + attraction.getId());
+        }
         this.id = attraction.getId();
         this.name = attraction.getName();
         this.thumbnail = attraction.getThumbnail();
@@ -50,8 +55,8 @@ public class AttractionSummaryResponse {
         this.cat2Name = cat2Name;
         this.cat3Name = cat3Name;
         this.address = attraction.getAddress();
-        this.lng = attraction.getGeom().getX();
-        this.lat = attraction.getGeom().getY();
+        this.lng = geom.getX();
+        this.lat = geom.getY();
         this.score = score != null ? score.getScore() : null;
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
@@ -47,13 +47,18 @@ public class AttractionQueryService {
                 .map(a -> new AttractionSummaryResponse(
                         a,
                         scoreMap.get(a.getId()),
-                        categoryNames.getOrDefault(a.getCat1(), a.getCat1()),
-                        categoryNames.getOrDefault(a.getCat2(), a.getCat2()),
-                        categoryNames.getOrDefault(a.getCat3(), a.getCat3())
+                        resolveCategoryName(categoryNames, a.getCat1()),
+                        resolveCategoryName(categoryNames, a.getCat2()),
+                        resolveCategoryName(categoryNames, a.getCat3())
                 ))
                 .sorted(Comparator.comparing(AttractionSummaryResponse::getScore,
                         Comparator.nullsLast(Comparator.reverseOrder())))
                 .collect(Collectors.toList());
+    }
+
+    private String resolveCategoryName(Map<String, String> categoryNames, String code) {
+        if (code == null) return "미분류";
+        return categoryNames.getOrDefault(code, "미분류");
     }
 
     @Transactional
@@ -82,9 +87,9 @@ public class AttractionQueryService {
 
         return new AttractionDetailResponse(
                 attraction,
-                categoryNames.getOrDefault(attraction.getCat1(), attraction.getCat1()),
-                categoryNames.getOrDefault(attraction.getCat2(), attraction.getCat2()),
-                categoryNames.getOrDefault(attraction.getCat3(), attraction.getCat3()),
+                resolveCategoryName(categoryNames, attraction.getCat1()),
+                resolveCategoryName(categoryNames, attraction.getCat2()),
+                resolveCategoryName(categoryNames, attraction.getCat3()),
                 scores
         );
     }


### PR DESCRIPTION
## 개요
> AttractionDetailResponse (및 AttractionSummaryResponse) 일부 필드의 null 처리가 미흡하여 프론트 표시 오류 또는 서버 NPE가 발생할 수 있음.

## 변경 사항
1. cat1Name / cat2Name / cat3Name — null → "미분류" 반환
2. scores 빈 Map — 지수 표시 불가 상태 처리
3. lng / lat — geom null 시 NPE 방지

## 관련 이슈
close #92
