### PR TITLE
[FEAT] 서울 실시간 혼잡도 스케줄러 및 검증

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/config/CityDataAreaTargets.java
+++ b/src/main/java/com/beyondtoursseoul/bts/config/CityDataAreaTargets.java
@@ -1,0 +1,15 @@
+package com.beyondtoursseoul.bts.config;
+
+import java.util.List;
+
+public class CityDataAreaTargets {
+
+    public CityDataAreaTargets() {
+    }
+
+    public static final List<String> AREA_NAMES = List.of(
+            "광화문·덕수궁",
+            "강남역",
+            "명동 관광특구"
+    );
+}

--- a/src/main/java/com/beyondtoursseoul/bts/scheduler/AreaCongestionScheduler.java
+++ b/src/main/java/com/beyondtoursseoul/bts/scheduler/AreaCongestionScheduler.java
@@ -1,0 +1,22 @@
+package com.beyondtoursseoul.bts.scheduler;
+
+import com.beyondtoursseoul.bts.service.AreaCongestionCollectService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AreaCongestionScheduler {
+
+    private final AreaCongestionCollectService areaCongestionCollectService;
+
+    @Scheduled(cron = "0 */30 * * * *", zone = "Asia/Seoul")
+    public void collectAreaCongestion() {
+        log.info("[AreaCongestionScheduler] collect start");
+        areaCongestionCollectService.collectAll();
+        log.info("[AreaCongestionScheduler] collect end");
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/AreaCongestionCollectService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AreaCongestionCollectService.java
@@ -1,5 +1,6 @@
 package com.beyondtoursseoul.bts.service;
 
+import com.beyondtoursseoul.bts.config.CityDataAreaTargets;
 import com.beyondtoursseoul.bts.domain.AreaCongestionRaw;
 import com.beyondtoursseoul.bts.dto.CityDataApiResponseDto;
 import com.beyondtoursseoul.bts.repository.AreaCongestionRawRepository;
@@ -102,18 +103,12 @@ public class AreaCongestionCollectService {
 
     @Transactional
     public void collectAll() {
-        List<String> TARGET_AREAS = List.of(
-                "광화문·덕수궁",
-                "강남역",
-                "명동 관광특구"
-        );
-
-        int total = TARGET_AREAS.size();
+        int total = CityDataAreaTargets.AREA_NAMES.size();
         int successCount = 0;
         int skippedCount = 0;
         int failedCount = 0;
 
-        for (String areaName : TARGET_AREAS) {
+        for (String areaName : CityDataAreaTargets.AREA_NAMES) {
             try {
                 CollectResult result = collectOne(areaName);
 


### PR DESCRIPTION
## 개요
서울 실시간 혼잡도 수집 배치가 자동으로 실행되도록 스케줄러를 추가하고, 실행 기준으로 정상 동작을 검증했습니다.

## 변경 사항
- `AreaCongestionScheduler` 추가
- `@EnableScheduling` 설정 추가
- `collectAll()` 이 스케줄러에서 호출되도록 연결
- 배치 결과 요약 로그 추가
- 수집 대상 목록을 별도 상수 파일로 분리

## 테스트
- [x] `./gradlew compileJava`
- [x] 스케줄러 자동 실행 로그 확인
- [x] `collectAll finished. total=3, success=3, skipped=0, failed=0` 확인
- [x] 스케줄러 시작/종료 로그 확인

## 관련 이슈
close #83 
