### PR TITLE
[FEAT] 관광지 수집 시 contentTypeId 15·25·32 제외

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionApiService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionApiService.java
@@ -19,6 +19,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -28,6 +29,8 @@ public class AttractionApiService {
     private static final String DETAIL_COMMON_URL = "https://apis.data.go.kr/B551011/KorService2/detailCommon2";
     private static final String DETAIL_INTRO_URL = "https://apis.data.go.kr/B551011/KorService2/detailIntro2";
     private static final String SEOUL_REGION_CD = "11";
+    // 행사/공연(15), 여행코스(25), 숙박(32)은 찐로컬 지수 추천 목적에 맞지 않아 수집 제외
+    private static final Set<String> EXCLUDED_CONTENT_TYPE_IDS = Set.of("15", "25", "32");
     private static final String SOURCE = "TOUR_API";
     private static final int PAGE_SIZE = 1000;
 
@@ -92,6 +95,9 @@ public class AttractionApiService {
     }
 
     private Optional<Attraction> toAttraction(Item item) {
+        if (EXCLUDED_CONTENT_TYPE_IDS.contains(item.getContentTypeId())) {
+            return Optional.empty();
+        }
         if (item.getMapX() == null || item.getMapX().isBlank()
                 || item.getMapY() == null || item.getMapY().isBlank()) {
             return Optional.empty();


### PR DESCRIPTION
## 개요
현재 TourAPI에서 서울 관광지를 수집할 때 모든 contentTypeId를 저장하고 있음.
행사/공연(15), 여행코스(25), 숙박(32)은 찐로컬 지수 기반 관광지 추천 서비스 목적과 맞지 않아 수집 대상에서 제외.

## 변경 사항

- AttractionApiService.toAttraction()에 contentTypeId 15·25·32 필터 추가
- Supabase에서 기존 저장된 해당 카테고리 데이터 삭제
  - (attraction_local_score → attraction 순서로 삭제)

## 관련 이슈
close #96
