### PR TITLE
[FIX] DailyScoreScheduler 스킵 조건을 dong_local_score 기준으로 변경

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/repository/DongLocalScoreRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/DongLocalScoreRepository.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 
 public interface DongLocalScoreRepository extends JpaRepository<DongLocalScore, Long> {
 
+    boolean existsByDate(LocalDate date);
+
     boolean existsByDongCodeAndDateAndTimeSlot(String dongCode, LocalDate date, String timeSlot);
 
     List<DongLocalScore> findByDate(LocalDate date);

--- a/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
+++ b/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
@@ -1,6 +1,6 @@
 package com.beyondtoursseoul.bts.scheduler;
 
-import com.beyondtoursseoul.bts.repository.DongPopulationRawRepository;
+import com.beyondtoursseoul.bts.repository.DongLocalScoreRepository;
 import com.beyondtoursseoul.bts.service.LocalResidentApiService;
 import com.beyondtoursseoul.bts.service.score.AttractionScoreService;
 import com.beyondtoursseoul.bts.service.score.LocalScoreCalculateService;
@@ -21,7 +21,7 @@ public class DailyScoreScheduler {
     private final PopulationCollectService populationCollectService;
     private final LocalScoreCalculateService localScoreCalculateService;
     private final AttractionScoreService attractionScoreService;
-    private final DongPopulationRawRepository rawRepository;
+    private final DongLocalScoreRepository localScoreRepository;
 
     @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
     public void run() {
@@ -29,7 +29,7 @@ public class DailyScoreScheduler {
         try {
             LocalDate targetDate = localResidentApiService.findLatestAvailableDate();
 
-            if (rawRepository.existsByDate(targetDate)) {
+            if (localScoreRepository.existsByDate(targetDate)) {
                 log.info("[DailyScoreScheduler] {} 데이터 이미 존재 — 스킵", targetDate);
                 return;
             }


### PR DESCRIPTION
## 개요
DailyScoreScheduler의 중복 실행 방지 조건이 dong_population_raw.existsByDate(targetDate)만 체크함. 1단계(생활인구 수집)가 성공하고 2단계(찐로컬 지수 계산)가 실패하면,
이후 실행에서 "이미 데이터 있음"으로 조기 반환되어 dong_local_score와 attraction_local_score가 영구적으로 계산되지 않는 상태가 됨.

실제 발생: dong_population_raw에는 2026-05-01 데이터가 존재하나, dong_local_score와 attraction_local_score의 최신 날짜는 2026-04-29에 머물러 있음.

## 변경 사항
DailyScoreScheduler의 스킵 조건을 rawRepository.existsByDate() → localScoreRepository.existsByDate()로 교체

## 관련 이슈
close #98
