### PR TITLE
[FEAT] 관광지 상세 정보 일괄 수집 배치 추가

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/exception/TourApiRateLimitException.java
+++ b/src/main/java/com/beyondtoursseoul/bts/exception/TourApiRateLimitException.java
@@ -1,0 +1,7 @@
+package com.beyondtoursseoul.bts.exception;
+
+public class TourApiRateLimitException extends RuntimeException {
+    public TourApiRateLimitException() {
+        super("TourAPI 일일 호출 한도 초과");
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/repository/AttractionRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/AttractionRepository.java
@@ -3,5 +3,9 @@ package com.beyondtoursseoul.bts.repository;
 import com.beyondtoursseoul.bts.domain.Attraction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AttractionRepository extends JpaRepository<Attraction, Long> {
+
+    List<Attraction> findByDetailFetchedFalseAndExternalIdNotNull();
 }

--- a/src/main/java/com/beyondtoursseoul/bts/runner/AttractionDetailBatchRunner.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/AttractionDetailBatchRunner.java
@@ -1,6 +1,7 @@
 package com.beyondtoursseoul.bts.runner;
 
 import com.beyondtoursseoul.bts.domain.Attraction;
+import com.beyondtoursseoul.bts.exception.TourApiRateLimitException;
 import com.beyondtoursseoul.bts.repository.AttractionRepository;
 import com.beyondtoursseoul.bts.service.AttractionApiService;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +54,10 @@ public class AttractionDetailBatchRunner implements ApplicationRunner {
                 }
 
                 Thread.sleep(DELAY_MS);
+            } catch (TourApiRateLimitException e) {
+                log.warn("[DetailBatch] API 일일 한도 초과 — 배치 중단. 나머지 {}건은 다음 실행에서 처리",
+                        total - success - failed);
+                break;
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 log.warn("[DetailBatch] 인터럽트 — 배치 중단 (완료: {}/{})", success, total);

--- a/src/main/java/com/beyondtoursseoul/bts/runner/AttractionDetailBatchRunner.java
+++ b/src/main/java/com/beyondtoursseoul/bts/runner/AttractionDetailBatchRunner.java
@@ -1,0 +1,69 @@
+package com.beyondtoursseoul.bts.runner;
+
+import com.beyondtoursseoul.bts.domain.Attraction;
+import com.beyondtoursseoul.bts.repository.AttractionRepository;
+import com.beyondtoursseoul.bts.service.AttractionApiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(3)
+public class AttractionDetailBatchRunner implements ApplicationRunner {
+
+    private static final int LOG_INTERVAL = 100;
+    private static final long DELAY_MS = 200;
+
+    private final AttractionRepository attractionRepository;
+    private final AttractionApiService attractionApiService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        List<Attraction> targets = attractionRepository.findByDetailFetchedFalseAndExternalIdNotNull();
+        if (targets.isEmpty()) {
+            log.info("[DetailBatch] 상세 정보 수집 대상 없음 — 스킵");
+            return;
+        }
+
+        int total = targets.size();
+        int success = 0;
+        int failed = 0;
+        log.info("[DetailBatch] 상세 정보 일괄 수집 시작: 총 {}건", total);
+
+        for (Attraction attraction : targets) {
+            try {
+                AttractionApiService.CommonDetail common =
+                        attractionApiService.fetchCommonDetail(attraction.getExternalId());
+                String operatingHours = attractionApiService.fetchOperatingHours(
+                        attraction.getExternalId(), attraction.getCategory());
+
+                attraction.updateDetail(common.overview(), operatingHours, common.tel());
+                attractionRepository.save(attraction);
+                success++;
+
+                if (success % LOG_INTERVAL == 0) {
+                    log.info("[DetailBatch] 진행 중: {} / {} 완료", success, total);
+                }
+
+                Thread.sleep(DELAY_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("[DetailBatch] 인터럽트 — 배치 중단 (완료: {}/{})", success, total);
+                return;
+            } catch (Exception e) {
+                failed++;
+                log.warn("[DetailBatch] 실패 (id={}, externalId={}): {}",
+                        attraction.getId(), attraction.getExternalId(), e.getMessage());
+            }
+        }
+
+        log.info("[DetailBatch] 완료 — 성공: {}건, 실패: {}건 / 전체: {}건", success, failed, total);
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionApiService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionApiService.java
@@ -5,7 +5,10 @@ import com.beyondtoursseoul.bts.dto.DetailCommonResponseDto;
 import com.beyondtoursseoul.bts.dto.DetailInfoResponseDto;
 import com.beyondtoursseoul.bts.dto.TourApiResponseDto;
 import com.beyondtoursseoul.bts.dto.TourApiResponseDto.Item;
+import com.beyondtoursseoul.bts.exception.TourApiRateLimitException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.client.RestClientResponseException;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -141,7 +144,7 @@ public class AttractionApiService {
                     + "&MobileOS=ETC&MobileApp=BTS&_type=json"
                     + "&contentId=" + contentId;
 
-            String json = restClient.get().uri(url).retrieve().body(String.class);
+            String json = fetchJson(url);
             DetailCommonResponseDto response = objectMapper.readValue(json, DetailCommonResponseDto.class);
 
             if (response == null
@@ -154,6 +157,8 @@ public class AttractionApiService {
             }
             DetailCommonResponseDto.Item item = response.getResponse().getBody().getItems().getItem().get(0);
             return new CommonDetail(blankToNull(item.getOverview()), blankToNull(item.getTel()));
+        } catch (TourApiRateLimitException e) {
+            throw e;
         } catch (Exception e) {
             log.warn("[AttractionApi] detailCommon2 조회 실패 contentId={}: {}", contentId, e.getMessage());
             return new CommonDetail(null, null);
@@ -168,7 +173,7 @@ public class AttractionApiService {
                     + "&contentId=" + contentId
                     + "&contentTypeId=" + contentTypeId;
 
-            String json = restClient.get().uri(url).retrieve().body(String.class);
+            String json = fetchJson(url);
             DetailInfoResponseDto response = objectMapper.readValue(json, DetailInfoResponseDto.class);
 
             if (response == null
@@ -180,10 +185,31 @@ public class AttractionApiService {
                 return null;
             }
             return response.getResponse().getBody().getItems().getItem().get(0).resolveOperatingHours();
+        } catch (TourApiRateLimitException e) {
+            throw e;
         } catch (Exception e) {
             log.warn("[AttractionApi] 운영시간 조회 실패 contentId={}: {}", contentId, e.getMessage());
             return null;
         }
+    }
+
+    private String fetchJson(String url) {
+        String json;
+        try {
+            json = restClient.get().uri(url).retrieve().body(String.class);
+        } catch (RestClientResponseException e) {
+            if (e.getStatusCode().value() == 429) throw new TourApiRateLimitException();
+            throw e;
+        }
+        try {
+            JsonNode resultCode = objectMapper.readTree(json)
+                    .path("response").path("header").path("resultCode");
+            if ("22".equals(resultCode.asText())) throw new TourApiRateLimitException();
+        } catch (TourApiRateLimitException e) {
+            throw e;
+        } catch (Exception ignored) {
+        }
+        return json;
     }
 
     private static String blankToNull(String value) {


### PR DESCRIPTION
## 개요
현재 관광지 상세 정보(overview, operatingHours, tel)는 첫 detail 조회 시 TourAPI를 호출하는 lazy 방식으로 수집됨. 이로 인해 첫 조회 사용자가 느린 응답을 받는 문제가
있음.

앱 기동 시 detail_fetched = false인 관광지 전체를 대상으로 TourAPI(detailCommon2, detailIntro2)를 순차 호출해 상세 정보를 일괄 수집하는 배치를 추가함. 7,500건 기준 약
15,000 API 호출 예상.
## 변경 사항

- AttractionDetailBatchRunner 생성 (@order(3), ApplicationRunner)

- detail_fetched = false 인 관광지만 조회해 순차 처리 (멱등성 보장)

- 각 관광지마다 detailCommon2 + detailIntro2 호출 후 updateDetail 저장

- API rate limit 대비 호출 간 딜레이 적용
 
- 진행 상황 로깅 (N건 완료 / 전체 M건)

## 관련 이슈
close #100
