### PR TITLE
[FEAT] 관광지 API 다국어(영·중·일) 지원

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
@@ -37,8 +37,10 @@ public class AttractionController {
             @Parameter(description = "조회 날짜 (yyyy-MM-dd). 미입력 시 DB 최신 날짜 사용")
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @Parameter(description = "시간대. morning/lunch/afternoon/evening/night", example = "afternoon")
-            @RequestParam(defaultValue = "afternoon") String timeSlot) {
-        return ResponseEntity.ok(attractionQueryService.getList(date, timeSlot));
+            @RequestParam(defaultValue = "afternoon") String timeSlot,
+            @Parameter(description = "언어 코드. ko(기본)/en/zh/ja")
+            @RequestHeader(value = "Accept-Language", required = false, defaultValue = "ko") String lang) {
+        return ResponseEntity.ok(attractionQueryService.getList(date, timeSlot, parseLang(lang)));
     }
 
     @Operation(
@@ -53,7 +55,14 @@ public class AttractionController {
     })
     @GetMapping("/{id}")
     public ResponseEntity<AttractionDetailResponse> getDetail(
-            @Parameter(description = "관광지 ID") @PathVariable Long id) {
-        return ResponseEntity.ok(attractionQueryService.getDetail(id));
+            @Parameter(description = "관광지 ID") @PathVariable Long id,
+            @Parameter(description = "언어 코드. ko(기본)/en/zh/ja")
+            @RequestHeader(value = "Accept-Language", required = false, defaultValue = "ko") String lang) {
+        return ResponseEntity.ok(attractionQueryService.getDetail(id, parseLang(lang)));
+    }
+
+    private String parseLang(String acceptLanguage) {
+        if (acceptLanguage == null || acceptLanguage.isBlank()) return "ko";
+        return acceptLanguage.split("[,;\\-]")[0].trim().toLowerCase();
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/domain/AttractionTranslation.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/AttractionTranslation.java
@@ -1,0 +1,40 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "attraction_translation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttractionTranslation {
+
+    @EmbeddedId
+    private AttractionTranslationId id;
+
+    @Column(columnDefinition = "TEXT")
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String address;
+
+    @Column(columnDefinition = "TEXT")
+    private String overview;
+
+    @Column(name = "operating_hours", columnDefinition = "TEXT")
+    private String operatingHours;
+
+    @Builder
+    public AttractionTranslation(Long attractionId, String lang,
+                                 String name, String address,
+                                 String overview, String operatingHours) {
+        this.id = new AttractionTranslationId(attractionId, lang);
+        this.name = name;
+        this.address = address;
+        this.overview = overview;
+        this.operatingHours = operatingHours;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/domain/AttractionTranslationId.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/AttractionTranslationId.java
@@ -1,0 +1,27 @@
+package com.beyondtoursseoul.bts.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode
+public class AttractionTranslationId implements Serializable {
+
+    @Column(name = "attraction_id")
+    private Long attractionId;
+
+    @Column(length = 10)
+    private String lang;
+
+    public AttractionTranslationId(Long attractionId, String lang) {
+        this.attractionId = attractionId;
+        this.lang = lang;
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionDetailResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionDetailResponse.java
@@ -1,6 +1,7 @@
 package com.beyondtoursseoul.bts.dto.attraction;
 
 import com.beyondtoursseoul.bts.domain.Attraction;
+import com.beyondtoursseoul.bts.domain.AttractionTranslation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.locationtech.jts.geom.Point;
@@ -56,23 +57,28 @@ public class AttractionDetailResponse {
 
     public AttractionDetailResponse(Attraction attraction,
                                     String cat1Name, String cat2Name, String cat3Name,
-                                    Map<String, BigDecimal> scores) {
+                                    Map<String, BigDecimal> scores,
+                                    AttractionTranslation translation) {
         Point geom = attraction.getGeom();
         if (geom == null) {
             throw new IllegalStateException("관광지 좌표 데이터가 없습니다: id=" + attraction.getId());
         }
         this.id = attraction.getId();
-        this.name = attraction.getName();
+        this.name = translation != null && translation.getName() != null
+                ? translation.getName() : attraction.getName();
         this.thumbnail = attraction.getThumbnail();
         this.cat1Name = cat1Name;
         this.cat2Name = cat2Name;
         this.cat3Name = cat3Name;
-        this.address = attraction.getAddress();
+        this.address = translation != null && translation.getAddress() != null
+                ? translation.getAddress() : attraction.getAddress();
         this.lng = geom.getX();
         this.lat = geom.getY();
         this.tel = attraction.getTel();
-        this.overview = attraction.getOverview();
-        this.operatingHours = attraction.getOperatingHours();
+        this.overview = translation != null && translation.getOverview() != null
+                ? translation.getOverview() : attraction.getOverview();
+        this.operatingHours = translation != null && translation.getOperatingHours() != null
+                ? translation.getOperatingHours() : attraction.getOperatingHours();
         this.scoresAvailable = scores != null && !scores.isEmpty();
         this.scores = scores;
     }

--- a/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionSummaryResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/attraction/AttractionSummaryResponse.java
@@ -2,6 +2,7 @@ package com.beyondtoursseoul.bts.dto.attraction;
 
 import com.beyondtoursseoul.bts.domain.Attraction;
 import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
+import com.beyondtoursseoul.bts.domain.AttractionTranslation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.locationtech.jts.geom.Point;
@@ -43,18 +44,21 @@ public class AttractionSummaryResponse {
     private final BigDecimal score;
 
     public AttractionSummaryResponse(Attraction attraction, AttractionLocalScore score,
-                                     String cat1Name, String cat2Name, String cat3Name) {
+                                     String cat1Name, String cat2Name, String cat3Name,
+                                     AttractionTranslation translation) {
         Point geom = attraction.getGeom();
         if (geom == null) {
             throw new IllegalStateException("관광지 좌표 데이터가 없습니다: id=" + attraction.getId());
         }
         this.id = attraction.getId();
-        this.name = attraction.getName();
+        this.name = translation != null && translation.getName() != null
+                ? translation.getName() : attraction.getName();
         this.thumbnail = attraction.getThumbnail();
         this.cat1Name = cat1Name;
         this.cat2Name = cat2Name;
         this.cat3Name = cat3Name;
-        this.address = attraction.getAddress();
+        this.address = translation != null && translation.getAddress() != null
+                ? translation.getAddress() : attraction.getAddress();
         this.lng = geom.getX();
         this.lat = geom.getY();
         this.score = score != null ? score.getScore() : null;

--- a/src/main/java/com/beyondtoursseoul/bts/repository/AttractionTranslationRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/AttractionTranslationRepository.java
@@ -1,0 +1,15 @@
+package com.beyondtoursseoul.bts.repository;
+
+import com.beyondtoursseoul.bts.domain.AttractionTranslation;
+import com.beyondtoursseoul.bts.domain.AttractionTranslationId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AttractionTranslationRepository extends JpaRepository<AttractionTranslation, AttractionTranslationId> {
+
+    Optional<AttractionTranslation> findByIdAttractionIdAndIdLang(Long attractionId, String lang);
+
+    List<AttractionTranslation> findByIdAttractionIdInAndIdLang(List<Long> attractionIds, String lang);
+}

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
@@ -2,15 +2,16 @@ package com.beyondtoursseoul.bts.service;
 
 import com.beyondtoursseoul.bts.domain.Attraction;
 import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
+import com.beyondtoursseoul.bts.domain.AttractionTranslation;
 import com.beyondtoursseoul.bts.dto.attraction.AttractionDetailResponse;
 import com.beyondtoursseoul.bts.dto.attraction.AttractionSummaryResponse;
 import com.beyondtoursseoul.bts.repository.AttractionLocalScoreRepository;
 import com.beyondtoursseoul.bts.repository.AttractionRepository;
+import com.beyondtoursseoul.bts.repository.AttractionTranslationRepository;
 import com.beyondtoursseoul.bts.repository.TourCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.annotation.Propagation;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -28,8 +29,9 @@ public class AttractionQueryService {
     private final AttractionLocalScoreRepository scoreRepository;
     private final TourCategoryRepository categoryRepository;
     private final AttractionApiService attractionApiService;
+    private final AttractionTranslationRepository translationRepository;
 
-    public List<AttractionSummaryResponse> getList(LocalDate date, String timeSlot) {
+    public List<AttractionSummaryResponse> getList(LocalDate date, String timeSlot, String lang) {
         LocalDate effectiveDate = date != null ? date
                 : scoreRepository.findLatestDate().orElse(LocalDate.now().minusDays(1));
 
@@ -42,14 +44,24 @@ public class AttractionQueryService {
                 .stream()
                 .collect(Collectors.toMap(c -> c.getCode(), c -> c.getName()));
 
-        return attractionRepository.findAll().stream()
+        List<Attraction> attractions = attractionRepository.findAll().stream()
                 .filter(a -> scoreMap.containsKey(a.getId()))
+                .collect(Collectors.toList());
+
+        Map<Long, AttractionTranslation> translationMap = isKorean(lang) ? Map.of()
+                : translationRepository.findByIdAttractionIdInAndIdLang(
+                        attractions.stream().map(Attraction::getId).collect(Collectors.toList()), lang)
+                  .stream()
+                  .collect(Collectors.toMap(t -> t.getId().getAttractionId(), t -> t));
+
+        return attractions.stream()
                 .map(a -> new AttractionSummaryResponse(
                         a,
                         scoreMap.get(a.getId()),
                         resolveCategoryName(categoryNames, a.getCat1()),
                         resolveCategoryName(categoryNames, a.getCat2()),
-                        resolveCategoryName(categoryNames, a.getCat3())
+                        resolveCategoryName(categoryNames, a.getCat3()),
+                        translationMap.get(a.getId())
                 ))
                 .sorted(Comparator.comparing(AttractionSummaryResponse::getScore,
                         Comparator.nullsLast(Comparator.reverseOrder())))
@@ -61,8 +73,12 @@ public class AttractionQueryService {
         return categoryNames.getOrDefault(code, "미분류");
     }
 
+    private boolean isKorean(String lang) {
+        return lang == null || lang.isBlank() || lang.toLowerCase().startsWith("ko");
+    }
+
     @Transactional
-    public AttractionDetailResponse getDetail(Long id) {
+    public AttractionDetailResponse getDetail(Long id, String lang) {
         Attraction attraction = attractionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("관광지를 찾을 수 없습니다: " + id));
 
@@ -85,12 +101,16 @@ public class AttractionQueryService {
                         AttractionLocalScore::getScore
                 ));
 
+        AttractionTranslation translation = isKorean(lang) ? null
+                : translationRepository.findByIdAttractionIdAndIdLang(id, lang).orElse(null);
+
         return new AttractionDetailResponse(
                 attraction,
                 resolveCategoryName(categoryNames, attraction.getCat1()),
                 resolveCategoryName(categoryNames, attraction.getCat2()),
                 resolveCategoryName(categoryNames, attraction.getCat3()),
-                scores
+                scores,
+                translation
         );
     }
 }


### PR DESCRIPTION
## 개요
현재 GET /api/v1/attractions, GET /api/v1/attractions/{id} 응답이 한국어로만 제공됨. Accept-Language 헤더로 언어를 지정하면 해당 언어로 번역된 데이터를 반환하도록
다국어 지원을 추가함.

지원 언어: ko(기본), en, zh, ja
번역 대상 필드: name, address, overview, operating_hours
번역 데이터는 직접 SQL로 삽입하며, 번역이 없는 경우 한국어 원본으로 fallback.

## 변경 사항


- Supabase에 attraction_translation 테이블 생성 (attraction_id, lang, name, address, overview, operating_hours)
- AttractionTranslation JPA 엔티티 추가
- AttractionTranslationRepository 추가
- AttractionController — Accept-Language 헤더 파라미터 추가
- AttractionQueryService.getList() / getDetail() — lang 파라미터 추가, 번역 테이블 조회 후 원본 fallback 처리 
- AttractionSummaryResponse, AttractionDetailResponse DTO — 번역값 주입 가능하도록 수정


## 관련 이슈
close #104
