### PR TITLE
[FEAT] 관광지 카테고리명 다국어 지원

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/domain/TourCategory.java
+++ b/src/main/java/com/beyondtoursseoul/bts/domain/TourCategory.java
@@ -19,6 +19,15 @@ public class TourCategory {
     @Column(length = 100, nullable = false)
     private String name;
 
+    @Column(name = "name_en", length = 100)
+    private String nameEn;
+
+    @Column(name = "name_zh", length = 100)
+    private String nameZh;
+
+    @Column(name = "name_ja", length = 100)
+    private String nameJa;
+
     @Column(nullable = false)
     private Integer level;
 
@@ -27,5 +36,15 @@ public class TourCategory {
         this.code = code;
         this.name = name;
         this.level = level;
+    }
+
+    public String getLocalizedName(String lang) {
+        if (lang == null) return name;
+        return switch (lang) {
+            case "en" -> nameEn != null ? nameEn : name;
+            case "zh" -> nameZh != null ? nameZh : name;
+            case "ja" -> nameJa != null ? nameJa : name;
+            default -> name;
+        };
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
@@ -3,6 +3,7 @@ package com.beyondtoursseoul.bts.service;
 import com.beyondtoursseoul.bts.domain.Attraction;
 import com.beyondtoursseoul.bts.domain.AttractionLocalScore;
 import com.beyondtoursseoul.bts.domain.AttractionTranslation;
+import com.beyondtoursseoul.bts.domain.TourCategory;
 import com.beyondtoursseoul.bts.dto.attraction.AttractionDetailResponse;
 import com.beyondtoursseoul.bts.dto.attraction.AttractionSummaryResponse;
 import com.beyondtoursseoul.bts.repository.AttractionLocalScoreRepository;
@@ -40,9 +41,9 @@ public class AttractionQueryService {
                 .stream()
                 .collect(Collectors.toMap(s -> s.getId().getAttractionId(), s -> s));
 
-        Map<String, String> categoryNames = categoryRepository.findAll()
+        Map<String, TourCategory> categories = categoryRepository.findAll()
                 .stream()
-                .collect(Collectors.toMap(c -> c.getCode(), c -> c.getName()));
+                .collect(Collectors.toMap(TourCategory::getCode, c -> c));
 
         List<Attraction> attractions = attractionRepository.findAll().stream()
                 .filter(a -> scoreMap.containsKey(a.getId()))
@@ -58,9 +59,9 @@ public class AttractionQueryService {
                 .map(a -> new AttractionSummaryResponse(
                         a,
                         scoreMap.get(a.getId()),
-                        resolveCategoryName(categoryNames, a.getCat1()),
-                        resolveCategoryName(categoryNames, a.getCat2()),
-                        resolveCategoryName(categoryNames, a.getCat3()),
+                        resolveCategoryName(categories, a.getCat1(), lang),
+                        resolveCategoryName(categories, a.getCat2(), lang),
+                        resolveCategoryName(categories, a.getCat3(), lang),
                         translationMap.get(a.getId())
                 ))
                 .sorted(Comparator.comparing(AttractionSummaryResponse::getScore,
@@ -68,9 +69,11 @@ public class AttractionQueryService {
                 .collect(Collectors.toList());
     }
 
-    private String resolveCategoryName(Map<String, String> categoryNames, String code) {
+    private String resolveCategoryName(Map<String, TourCategory> categories, String code, String lang) {
         if (code == null) return "미분류";
-        return categoryNames.getOrDefault(code, "미분류");
+        TourCategory category = categories.get(code);
+        if (category == null) return "미분류";
+        return category.getLocalizedName(lang);
     }
 
     private boolean isKorean(String lang) {
@@ -89,9 +92,9 @@ public class AttractionQueryService {
             attraction.updateDetail(common.overview(), operatingHours, common.tel());
         }
 
-        Map<String, String> categoryNames = categoryRepository.findAll()
+        Map<String, TourCategory> categories = categoryRepository.findAll()
                 .stream()
-                .collect(Collectors.toMap(c -> c.getCode(), c -> c.getName()));
+                .collect(Collectors.toMap(TourCategory::getCode, c -> c));
 
         LocalDate latestDate = scoreRepository.findLatestDate().orElse(LocalDate.now().minusDays(1));
         Map<String, BigDecimal> scores = scoreRepository.findByIdAttractionIdAndIdDate(id, latestDate)
@@ -106,9 +109,9 @@ public class AttractionQueryService {
 
         return new AttractionDetailResponse(
                 attraction,
-                resolveCategoryName(categoryNames, attraction.getCat1()),
-                resolveCategoryName(categoryNames, attraction.getCat2()),
-                resolveCategoryName(categoryNames, attraction.getCat3()),
+                resolveCategoryName(categories, attraction.getCat1(), lang),
+                resolveCategoryName(categories, attraction.getCat2(), lang),
+                resolveCategoryName(categories, attraction.getCat3(), lang),
                 scores,
                 translation
         );


### PR DESCRIPTION
## 개요
현재 GET /api/v1/attractions, GET /api/v1/attractions/{id} 응답이 한국어로만 제공됨. Accept-Language 헤더로 언어를 지정하면 해당 언어로 번역된 데이터를 반환하도록
다국어 지원을 추가함.

## 변경 사항
  - `Accept-Language` 헤더(ko/en/zh/ja)에 따라 관광지 목록·상세 응답을 다국어로 반환                                                                                    
  - 번역 데이터는 `attraction_translation` 테이블에 사전 저장, 없는 경우 한국어 원본 fallback                                                                              
  -  `tour_category` 카테고리명도 언어별 컬럼(name_en/zh/ja) 추가하여 다국어 반환

## 관련 이슈
close #107
