### PR TITLE
[FEAT] 혼잡도 조회 API 및 Swagger 문서 추가

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/controller/AreaCongestionController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/AreaCongestionController.java
@@ -1,0 +1,53 @@
+package com.beyondtoursseoul.bts.controller;
+
+import com.beyondtoursseoul.bts.dto.congestion.AreaCongestionResponse;
+import com.beyondtoursseoul.bts.service.AreaCongestionQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Congestion", description = "서울 실시간 혼잡도 조회 API")
+@RestController
+@RequestMapping("/api/v1/congestion")
+@RequiredArgsConstructor
+public class AreaCongestionController {
+
+    private final AreaCongestionQueryService areaCongestionQueryService;
+
+    @Operation(
+            summary = "지역 혼잡도 목록 조회",
+            description = "DB에 저장된 전체 지역의 최신 혼잡도 정보를 반영합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<List<AreaCongestionResponse>> getList() {
+        return ResponseEntity.ok(areaCongestionQueryService.getList());
+    }
+
+    @Operation(
+            summary = "지역 혼잡도 단건 조회",
+            description = "areaCode 기준으로 특정 지역의 최신 혼잡도 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 지역을 찾을 수 없음")
+    })
+    @GetMapping("/{areaCode}")
+    public ResponseEntity<AreaCongestionResponse> getDetail(
+            @Parameter(description = "지역 코드", example = "POI009")
+            @PathVariable String areaCode) {
+        return ResponseEntity.ok(areaCongestionQueryService.getDetail(areaCode));
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/dto/congestion/AreaCongestionResponse.java
+++ b/src/main/java/com/beyondtoursseoul/bts/dto/congestion/AreaCongestionResponse.java
@@ -1,0 +1,48 @@
+package com.beyondtoursseoul.bts.dto.congestion;
+
+import com.beyondtoursseoul.bts.domain.AreaCongestionRaw;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "지역 혼잡도 조회 응답 DTO")
+public class AreaCongestionResponse {
+
+    @Schema(description = "지역 코드", example = "POI009")
+    private String areaCode;
+
+    @Schema(description = "지역명", example = "광화문·덕수궁")
+    private String areaName;
+
+    @Schema(description = "혼잡도 수준", example = "약간 붐빔")
+    private String congestionLevel;
+
+    @Schema(description = "위도", example = "37.5695270714")
+    private Double latitude;
+
+    @Schema(description = "경도", example = "126.9768018471")
+    private Double longitude;
+
+    @Schema(description = "인구 기준 시각")
+    private LocalDateTime populationTime;
+
+    @Schema(description = "수집 시각")
+    private OffsetDateTime collectedAt;
+
+    public static AreaCongestionResponse from(AreaCongestionRaw raw) {
+        return new AreaCongestionResponse(
+                raw.getAreaCode(),
+                raw.getAreaName(),
+                raw.getCongestionLevel(),
+                raw.getLatitude(),
+                raw.getLongitude(),
+                raw.getPopulationTime(),
+                raw.getCollectedAt()
+        );
+    }
+}

--- a/src/main/java/com/beyondtoursseoul/bts/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/beyondtoursseoul/bts/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -40,5 +41,20 @@ public class GlobalExceptionHandler {
         body.put("message", e.getMessage());
         body.put("path", request.getRequestURI());
         return ResponseEntity.internalServerError().body(body);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleResponseStatusException(
+            ResponseStatusException e,
+            HttpServletRequest request
+    ) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now());
+        body.put("status", e.getStatusCode().value());
+        body.put("error", e.getStatusCode().toString());
+        body.put("message", e.getReason());
+        body.put("path", request.getRequestURI());
+
+        return ResponseEntity.status(e.getStatusCode()).body(body);
     }
 }

--- a/src/main/java/com/beyondtoursseoul/bts/repository/AreaCongestionRawRepository.java
+++ b/src/main/java/com/beyondtoursseoul/bts/repository/AreaCongestionRawRepository.java
@@ -3,9 +3,12 @@ package com.beyondtoursseoul.bts.repository;
 import com.beyondtoursseoul.bts.domain.AreaCongestionRaw;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AreaCongestionRawRepository extends JpaRepository<AreaCongestionRaw, Long> {
 
     Optional<AreaCongestionRaw> findByAreaCode(String areaCode);
+
+    List<AreaCongestionRaw> findAllByOrderByAreaNameAsc();
 }

--- a/src/main/java/com/beyondtoursseoul/bts/service/AreaCongestionQueryService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AreaCongestionQueryService.java
@@ -1,0 +1,32 @@
+package com.beyondtoursseoul.bts.service;
+
+import com.beyondtoursseoul.bts.dto.congestion.AreaCongestionResponse;
+import com.beyondtoursseoul.bts.repository.AreaCongestionRawRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AreaCongestionQueryService {
+
+    private final AreaCongestionRawRepository areaCongestionRawRepository;
+
+    public List<AreaCongestionResponse> getList() {
+        return areaCongestionRawRepository.findAllByOrderByAreaNameAsc().stream()
+                .map(AreaCongestionResponse::from)
+                .toList();
+    }
+
+    public AreaCongestionResponse getDetail(String areaCode) {
+        return areaCongestionRawRepository.findByAreaCode(areaCode)
+                .map(AreaCongestionResponse::from)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "해당 지역 혼잡도 데이터를 찾을 수 없습니다. areaCode=" + areaCode
+                ));
+    }
+}


### PR DESCRIPTION
## 개요
DB에 저장된 혼잡도 데이터를 프론트에서 사용할 수 있도록 조회 API를 추가하고 Swagger 문서를 정리했습니다.

## 변경 사항
- 혼잡도 목록 조회 API 추가
- 혼잡도 단건 조회 API 추가
- 응답 DTO 정의
- 조회 서비스 구현
- Swagger 문서 추가
- 예외 응답 형식 정리

## 테스트
- 존재하는 지역 코드 조회 시 200 응답 확인
- 존재하지 않는 지역 코드 조회 시 404 응답 확인
- Swagger에서 응답 결과 수동 검증

## 관련 이슈
close #109 
