### PR TITLE
[REFACTOR] GET /api/v1/attractions 엔드포인트에 로컬 점수 범위 필터링 기능 추가

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
@@ -13,6 +13,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -38,9 +39,13 @@ public class AttractionController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @Parameter(description = "시간대. morning/lunch/afternoon/evening/night", example = "afternoon")
             @RequestParam(defaultValue = "afternoon") String timeSlot,
+            @Parameter(description = "찐로컬 지수 최솟값 (0~1). 미입력 시 하한 없음")
+            @RequestParam(required = false) BigDecimal minScore,
+            @Parameter(description = "찐로컬 지수 최댓값 (0~1). 미입력 시 상한 없음")
+            @RequestParam(required = false) BigDecimal maxScore,
             @Parameter(description = "언어 코드. ko(기본)/en/zh/ja")
             @RequestHeader(value = "Accept-Language", required = false, defaultValue = "ko") String lang) {
-        return ResponseEntity.ok(attractionQueryService.getList(date, timeSlot, parseLang(lang)));
+        return ResponseEntity.ok(attractionQueryService.getList(date, timeSlot, minScore, maxScore, parseLang(lang)));
     }
 
     @Operation(

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
@@ -32,7 +32,9 @@ public class AttractionQueryService {
     private final AttractionApiService attractionApiService;
     private final AttractionTranslationRepository translationRepository;
 
-    public List<AttractionSummaryResponse> getList(LocalDate date, String timeSlot, String lang) {
+    public List<AttractionSummaryResponse> getList(LocalDate date, String timeSlot,
+                                                    BigDecimal minScore, BigDecimal maxScore,
+                                                    String lang) {
         LocalDate effectiveDate = date != null ? date
                 : scoreRepository.findLatestDate().orElse(LocalDate.now().minusDays(1));
 
@@ -47,6 +49,7 @@ public class AttractionQueryService {
 
         List<Attraction> attractions = attractionRepository.findAll().stream()
                 .filter(a -> scoreMap.containsKey(a.getId()))
+                .filter(a -> isInScoreRange(scoreMap.get(a.getId()).getScore(), minScore, maxScore))
                 .collect(Collectors.toList());
 
         Map<Long, AttractionTranslation> translationMap = isKorean(lang) ? Map.of()
@@ -67,6 +70,13 @@ public class AttractionQueryService {
                 .sorted(Comparator.comparing(AttractionSummaryResponse::getScore,
                         Comparator.nullsLast(Comparator.reverseOrder())))
                 .collect(Collectors.toList());
+    }
+
+    private boolean isInScoreRange(BigDecimal score, BigDecimal min, BigDecimal max) {
+        if (score == null) return min == null && max == null;
+        if (min != null && score.compareTo(min) < 0) return false;
+        if (max != null && score.compareTo(max) > 0) return false;
+        return true;
     }
 
     private String resolveCategoryName(Map<String, TourCategory> categories, String code, String lang) {


### PR DESCRIPTION
## 개요
GET /api/v1/attractions 엔드포인트에 로컬 점수 범위 필터링 기능 추가

minScore만 입력 시 → score ≥ minScore
maxScore만 입력 시 → score ≤ maxScore
둘 다 입력 시 → minScore ≤ score ≤ maxScore

## 변경 사항


- AttractionController.java
  - minScore, maxScore 쿼리 파라미터 추가 (둘 다 optional, BigDecimal)
  - AttractionQueryService.getList()에 두 파라미터 전달

- AttractionQueryService.java
  - getList() 시그니처에 BigDecimal minScore, BigDecimal maxScore 추가
  - 스트림 필터 단계에서 score 범위 조건 적용

## 관련 이슈
close #112
