### PR TITLE
[CHORE] Virtual Treads 활성화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   application:
     name: bts
 
+  threads:
+    virtual:
+      enabled: true
+
   datasource:
     url: ${SUPABASE_DB_URL}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 개요
  코드 수정 없이 설정과 인프라 레벨만 변경해 성능을 개선합니다.

  1. Virtual Threads 활성화
     - TourAPI 같은 블로킹 I/O 호출 시 Tomcat 스레드가 점유된 채로 대기함
     - Virtual Threads를 활성화하면 블로킹 중 carrier thread를 반환해 다른 요청 처리 가능

  2. attraction_local_score (date, time_slot) 복합 인덱스 추가
     - 목록/페이지 쿼리의 핵심 필터가 date + time_slot 조합이지만
       PK가 (attraction_id, date, time_slot) 순서라 date 단독 필터 시 인덱스 효율 저하
     - 별도 인덱스 추가로 전체 스캔 → 인덱스 범위 스캔으로 전환
## 변경 사항
-  `application.yml`에 Virtual Threads 활성화 옵션 추가
        spring.threads.virtual.enabled: true
-  Supabase SQL Editor에서 복합 인덱스 생성
        CREATE INDEX IF NOT EXISTS idx_als_date_timeslot
          ON attraction_local_score (date, time_slot);


## 관련 이슈
close #128

