### PR TITLE
[REFACTOR] 관광지 API 캐시 전략 개선

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
+++ b/src/main/java/com/beyondtoursseoul/bts/controller/AttractionController.java
@@ -10,8 +10,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.TimeUnit;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -48,7 +51,9 @@ public class AttractionController {
             @RequestParam(required = false) BigDecimal maxScore,
             @Parameter(description = "언어 코드. ko(기본)/en/zh/ja")
             @RequestHeader(value = "Accept-Language", required = false, defaultValue = "ko") String lang) {
-        return ResponseEntity.ok(attractionQueryService.getList(date, timeSlot, minScore, maxScore, parseLang(lang)));
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS).cachePublic())
+                .body(attractionQueryService.getList(date, timeSlot, minScore, maxScore, parseLang(lang)));
     }
 
 
@@ -79,8 +84,10 @@ public class AttractionController {
         Pageable pageable = PageRequest.of(page, size);
 
         // 파라미터에 category를 추가하여 서비스로 넘깁니다.
-        return ResponseEntity.ok(attractionQueryService.getListPage(
-                category, date, timeSlot, minScore, maxScore, parseLang(lang), pageable));
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS).cachePublic())
+                .body(attractionQueryService.getListPage(
+                        category, date, timeSlot, minScore, maxScore, parseLang(lang), pageable));
     }
 
 

--- a/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
+++ b/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
@@ -27,7 +27,8 @@ public class DailyScoreScheduler {
 
     @Caching(evict = {
             @CacheEvict(value = "attractions", allEntries = true),
-            @CacheEvict(value = "attractionsPage", allEntries = true)
+            @CacheEvict(value = "attractionsPage", allEntries = true),
+            @CacheEvict(value = "tourCategories", allEntries = true)
     })
     @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
     public void run() {

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
@@ -11,7 +11,9 @@ import com.beyondtoursseoul.bts.repository.AttractionRepository;
 import com.beyondtoursseoul.bts.repository.AttractionTranslationRepository;
 import com.beyondtoursseoul.bts.repository.TourCategoryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -37,6 +39,10 @@ public class AttractionQueryService {
     private final AttractionApiService attractionApiService;
     private final AttractionTranslationRepository translationRepository;
 
+    @Lazy
+    @Autowired
+    private AttractionQueryService self;
+
 
     // 캐시 키에 #category 추가
     @Cacheable(value = "attractionsPage", key = "{#category, #date, #timeSlot, #minScore, #maxScore, #lang, #pageable.pageNumber}")
@@ -60,9 +66,7 @@ public class AttractionQueryService {
             return Page.empty(pageable);
         }
 
-        Map<String, TourCategory> categories = categoryRepository.findAll()
-                .stream()
-                .collect(Collectors.toMap(TourCategory::getCode, c -> c));
+        Map<String, TourCategory> categories = self.getCategoryMap();
 
         // 3. 가져온 10개의 ID만 추출
         List<Long> attractionIds = pageResult.stream()
@@ -106,9 +110,7 @@ public class AttractionQueryService {
         List<Object[]> rows = attractionRepository.findWithLocalScoresForList(
                 effectiveDate, timeSlot, minScore, maxScore);
 
-        Map<String, TourCategory> categories = categoryRepository.findAll()
-                .stream()
-                .collect(Collectors.toMap(TourCategory::getCode, c -> c));
+        Map<String, TourCategory> categories = self.getCategoryMap();
 
         List<Long> attractionIds = rows.stream()
                 .map(r -> ((Attraction) r[0]).getId())
@@ -134,6 +136,13 @@ public class AttractionQueryService {
             ));
         }
         return out;
+    }
+
+    @Cacheable("tourCategories")
+    public Map<String, TourCategory> getCategoryMap() {
+        return categoryRepository.findAll()
+                .stream()
+                .collect(Collectors.toMap(TourCategory::getCode, c -> c));
     }
 
     private boolean isInScoreRange(BigDecimal score, BigDecimal min, BigDecimal max) {
@@ -172,9 +181,7 @@ public class AttractionQueryService {
             attraction.updateDetail(common.overview(), operatingHours, common.tel());
         }
 
-        Map<String, TourCategory> categories = categoryRepository.findAll()
-                .stream()
-                .collect(Collectors.toMap(TourCategory::getCode, c -> c));
+        Map<String, TourCategory> categories = self.getCategoryMap();
 
         LocalDate latestDate = scoreRepository.findLatestDate().orElse(LocalDate.now().minusDays(1));
         Map<String, BigDecimal> scores = scoreRepository.findByIdAttractionIdAndIdDate(id, latestDate)


### PR DESCRIPTION
## 개요

  관광지 점수 데이터는 하루 1회 갱신되지만 현재 캐시 전략에 3가지 문제가 있습니다.

  1. HTTP Cache-Control 헤더 없음
     - 동일 파라미터 반복 요청이 매번 서버까지 도달
     - 브라우저/CDN 캐시를 전혀 활용하지 못하는 상태

  2. 캐시 Evict 미처리
     - @Cacheable에 TTL이 없어 매일 01:00 KST 점수 재계산 후에도
       캐시가 살아있으면 구 버전 점수가 계속 응답됨

  3. TourCategory 매 요청마다 전체 조회
     - getList, getListPage, getDetail 세 메서드 모두 매 호출마다
       categoryRepository.findAll()로 tour_category 전체 로드
     - 카테고리 데이터는 앱 기동 후 거의 변경 없음

## 변경 사항
  -  AttractionController의 getList, getListPage 응답에 Cache-Control 헤더 추가
        CacheControl.maxAge(1, TimeUnit.HOURS).cachePublic()
  -  DailyScoreScheduler 완료 시점에 attractions, attractionsPage 캐시 Evict
        @CacheEvict(value = {"attractions", "attractionsPage"}, allEntries = true)
  -  AttractionQueryService에 TourCategory 조회 전용 @Cacheable 메서드 분리
        getCategoryMap() → 세 메서드에서 공통 사용

## 관련 이슈
close #129
