### PR TITLE
[REFACTOR] getDetail TourAPI 동기 블로킹 호출 제거

### DIFF
--- a/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
+++ b/src/main/java/com/beyondtoursseoul/bts/scheduler/DailyScoreScheduler.java
@@ -28,7 +28,8 @@ public class DailyScoreScheduler {
     @Caching(evict = {
             @CacheEvict(value = "attractions", allEntries = true),
             @CacheEvict(value = "attractionsPage", allEntries = true),
-            @CacheEvict(value = "tourCategories", allEntries = true)
+            @CacheEvict(value = "tourCategories", allEntries = true),
+            @CacheEvict(value = "attractionDetail", allEntries = true)
     })
     @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
     public void run() {

--- a/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
+++ b/src/main/java/com/beyondtoursseoul/bts/service/AttractionQueryService.java
@@ -10,6 +10,7 @@ import com.beyondtoursseoul.bts.repository.AttractionLocalScoreRepository;
 import com.beyondtoursseoul.bts.repository.AttractionRepository;
 import com.beyondtoursseoul.bts.repository.AttractionTranslationRepository;
 import com.beyondtoursseoul.bts.repository.TourCategoryRepository;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
@@ -36,7 +37,6 @@ public class AttractionQueryService {
     private final AttractionRepository attractionRepository;
     private final AttractionLocalScoreRepository scoreRepository;
     private final TourCategoryRepository categoryRepository;
-    private final AttractionApiService attractionApiService;
     private final AttractionTranslationRepository translationRepository;
 
     @Lazy
@@ -169,17 +169,11 @@ public class AttractionQueryService {
         return lang == null || lang.isBlank() || lang.toLowerCase().startsWith("ko");
     }
 
-    @Transactional
+    @Cacheable(value = "attractionDetail", key = "{#id, #lang}")
+    @Transactional(readOnly = true)
     public AttractionDetailResponse getDetail(Long id, String lang) {
         Attraction attraction = attractionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("관광지를 찾을 수 없습니다: " + id));
-
-        if (!attraction.isDetailFetched() && attraction.getExternalId() != null) {
-            AttractionApiService.CommonDetail common = attractionApiService.fetchCommonDetail(attraction.getExternalId());
-            String operatingHours = attractionApiService.fetchOperatingHours(
-                    attraction.getExternalId(), attraction.getCategory());
-            attraction.updateDetail(common.overview(), operatingHours, common.tel());
-        }
 
         Map<String, TourCategory> categories = self.getCategoryMap();
 


### PR DESCRIPTION
## 개요

GET /api/v1/attractions/{id} 최초 조회 시 TourAPI를 동기·순차로 2회 호출합니다.
  (fetchCommonDetail + fetchOperatingHours)

  - TourAPI 응답 지연(수 초)이 사용자 응답 지연으로 직접 전파
  - TourAPI 장애 시 getDetail 전체가 블로킹
  - detailFetched = false인 관광지가 많을수록 첫 조회들이 모두 느림

  AttractionDetailBatchRunner가 이미 존재하므로 앱 기동/배치 시점에
  선처리하도록 완성하면 getDetail 핫패스에서 TourAPI 호출을 완전히 제거할 수 있습니다.

## 변경 사항
 - AttractionDetailBatchRunner에서 detailFetched = false인 관광지 전체 선처리
        - fetchCommonDetail + fetchOperatingHours 순차 호출 후 updateDetail 저장
        - Rate Limit 대응 (AttractionApiService의 기존 429 처리 로직 활용)
 -  AttractionQueryService.getDetail()에서 TourAPI 호출 블록 제거
        - detailFetched = false여도 overview/tel/operatingHours를 null로 응답
 -  getDetail에 @Cacheable 추가 (TourAPI 제거 후 트랜잭션 충돌 없으므로 적용 가능)
        @Cacheable(value = "attractionDetail", key = "{#id, #lang}")

## 관련 이슈
close #130

